### PR TITLE
chore: sort results by minzipped size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,12 +207,12 @@ _Want to see more projects listed?_ PRs welcome! See the [contribution guide](/.
 ## 🥇 Results
 
 #### Best minification performance
-[UglifyJS](https://github.com/mishoo/UglifyJS) takes first place for minification performance by winning 9 out of 11 races. When short, it only loses to Google Closure Compiler by less than `9 kB`! Impressively, it's still written in ES5 but can handle ES6 up to ES2020.
+[UglifyJS](https://github.com/mishoo/UglifyJS) takes first place for minification performance by winning 9 out of 11 races! Impressively, it's still written in ES5 but can handle ES6 up to ES2020.
 
-[Terser](https://github.com/terser/terser) takes a very close second, only short by at most by 1~2%. Terser is a fork of uglify-es and comes with support for ES6+.
+[Terser](https://github.com/terser/terser) takes a very close second, only short by at most by 1% in minzipped size while performing twice as fast as Uglify! Terser is a fork of UglifyJS and comes with support for ES6+.
 
 #### Fastest minifier
-[esbuild](https://github.com/evanw/esbuild) runs _10x_+ laps around everyone else! The Go-lang JS minifier/bundler is a beast of its own. Not only is it insanely fast, but demonstrates very competitive minification abilities, usually performing closely to Terser while supporting cutting-edge [ESNext syntax](https://esbuild.github.io/content-types/#javascript). However, note that esbuild has a [limited set of optimizations](https://github.com/evanw/esbuild/issues/639#:~:text=i%20can%20add%20a%20caveat%20to%20esbuild's%20minification%20documentation%20about%20code%20optimizations%20that%20are%20not%20included%20in%20esbuild.%20i%20think%20the%20list%20of%20possible%20code%20optimizations%20that%20esbuild%20doesn't%20do%20would%20be%20something%20like%20this%3A) and currently has [no plans to improve it](https://github.com/evanw/esbuild/issues/639#issuecomment-792033958).
+[esbuild](https://github.com/evanw/esbuild) runs _10x_+ laps around everyone else! The Go-lang JS minifier/bundler is a beast of its own. Not only is it insanely fast, but demonstrates very competitive minification abilities, usually performing closely to Terser while supporting cutting-edge [ESNext syntax](https://esbuild.github.io/content-types/#javascript). However, note that esbuild has a [limited set of optimizations](https://github.com/evanw/esbuild/issues/639#:~:text=i%20can%20add%20a%20caveat%20to%20esbuild's%20minification%20documentation%20about%20code%20optimizations%20that%20are%20not%20included%20in%20esbuild.%20i%20think%20the%20list%20of%20possible%20code%20optimizations%20that%20esbuild%20doesn't%20do%20would%20be%20something%20like%20this%3A) and there are currently [no plans to improve it](https://github.com/evanw/esbuild/issues/639#issuecomment-792033958).
 
 _⚡️ Pro Tip: Harness the speed of esbuild in your Webpack build for minification (and even transpilation) with [esbuild-loader](https://github.com/privatenumber/esbuild-loader)._
 

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,10 @@ Benchmarks are gathered on the following minifiers:
 
 - Each minifier is executed in its own process with a 1 minute timeout
 - The measured time is an average taken from 5 consecutive runs
-- Each table is sorted by smallest minified size in ascending order
-- Each time is annotated with a multiplier relative to the fastest minifier
 - _"Minzipped size"_ measures how well the minified file compresses with Gzip
+- Each table is sorted by smallest minzipped size in ascending order
+- Each time is annotated with a multiplier relative to the fastest minifier
+- Minified artifacts are validated by a smoke test
 - Minified artifacts can be downloaded and verified in each [action run](https://github.com/privatenumber/minification-benchmarks/actions/workflows/benchmark.yml)
 
 ## 📋 Results

--- a/scripts/update-benchmarks-readme/update-readme.ts
+++ b/scripts/update-benchmarks-readme/update-readme.ts
@@ -52,7 +52,7 @@ function processData(results: MinifierBenchmarksResultObject) {
 			time: avgTime,
 		};
 	}).sort(
-		(a, b) => (a.minifiedSize ?? PositiveInfinity) - (b.minifiedSize ?? PositiveInfinity),
+		(a, b) => (a.minzippedSize ?? PositiveInfinity) - (b.minzippedSize ?? PositiveInfinity),
 	);
 }
 


### PR DESCRIPTION
- As per @kzc's [suggestion](https://github.com/privatenumber/minification-benchmarks/pull/26#issuecomment-893729728), minifiers are sorted by minzipped size because over-the-wire size matters more at the end of the day
- Updated README (WIP)