### PR TITLE
chore: use vue umd

### DIFF
--- a/lib/artifacts/vue.ts
+++ b/lib/artifacts/vue.ts
@@ -4,7 +4,7 @@ import { requireString } from '../utils/require-string';
 import { artifactMeta } from '../types';
 
 export default artifactMeta({
-	path: 'vue/dist/vue.runtime.common.dev.js',
+	path: 'vue/dist/vue.js',
 	test(code) {
 		const Vue = requireString(code);
 		Vue.config.devtools = false;

--- a/lib/minifiers/esbuild.ts
+++ b/lib/minifiers/esbuild.ts
@@ -6,7 +6,6 @@ export default minifier(async ({ code }) => {
 		minify: true,
 		sourcemap: false,
 		legalComments: 'none',
-		format: 'cjs',
 	});
 
 	return minified.code;

--- a/lib/minifiers/esbuild.ts
+++ b/lib/minifiers/esbuild.ts
@@ -6,6 +6,7 @@ export default minifier(async ({ code }) => {
 		minify: true,
 		sourcemap: false,
 		legalComments: 'none',
+		format: 'cjs',
 	});
 
 	return minified.code;

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The following JavaScript minifiers are benchmarked to compare quality and speed:
 - [terser](https://github.com/terser/terser)
 - [uglify-js](https://github.com/mishoo/UglifyJS)
 
-_Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdated:end -->._
+_Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdated:end -->._
 
 <sub>Support this project by ⭐️ starring and sharing it. [Follow me](https://github.com/privatenumber) to see what other cool projects I'm working on! ❤️</sub>
 
@@ -31,14 +31,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                  Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | ------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-68% </sup>`22.83 kB`** | **<sup>🏆-58% </sup>`8.21 kB`** |  <sup>*50x* </sup>`1,040 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-68% </sup>`23.12 kB` |       <sup>-57% </sup>`8.29 kB` |    <sup>*24x* </sup>`507 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-68% </sup>`23.10 kB` |       <sup>-57% </sup>`8.33 kB` |      <sup>*2x* </sup>`47 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-67% </sup>`23.53 kB` |       <sup>-57% </sup>`8.38 kB` |  <sup>*67x* </sup>`1,387 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-67% </sup>`23.73 kB` |       <sup>-56% </sup>`8.56 kB` |    **<sup>🏆 </sup>`21 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`25.06 kB` |       <sup>-56% </sup>`8.65 kB` |     <sup>*8x* </sup>`182 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-65% </sup>`25.08 kB` |       <sup>-55% </sup>`8.72 kB` |    <sup>*11x* </sup>`246 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-55% </sup>`32.76 kB` |      <sup>-43% </sup>`11.10 kB` | <sup>*319x* </sup>`6,608 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-68% </sup>`22.83 kB`** | **<sup>🏆-58% </sup>`8.21 kB`** |    <sup>*43x* </sup>`757 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-68% </sup>`23.12 kB` |       <sup>-57% </sup>`8.29 kB` |    <sup>*21x* </sup>`376 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-68% </sup>`23.10 kB` |       <sup>-57% </sup>`8.33 kB` |      <sup>*1x* </sup>`32 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-67% </sup>`23.53 kB` |       <sup>-57% </sup>`8.38 kB` |  <sup>*57x* </sup>`1,001 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-67% </sup>`23.73 kB` |       <sup>-56% </sup>`8.55 kB` |    **<sup>🏆 </sup>`17 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`25.06 kB` |       <sup>-56% </sup>`8.65 kB` |     <sup>*7x* </sup>`138 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-65% </sup>`25.08 kB` |       <sup>-55% </sup>`8.72 kB` |    <sup>*10x* </sup>`179 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-55% </sup>`32.76 kB` |      <sup>-43% </sup>`11.10 kB` | <sup>*266x* </sup>`4,656 ms` |
 ----
 | Artifact                                                            | Original size |  Gzip size |
 | :------------------------------------------------------------------ | ------------: | ---------: |
@@ -46,29 +46,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`58.33 kB`** | **<sup>🏆-49% </sup>`18.49 kB`** |  <sup>*75x* </sup>`2,387 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`59.05 kB` |       <sup>-49% </sup>`18.59 kB` |  <sup>*41x* </sup>`1,317 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`59.11 kB` |       <sup>-49% </sup>`18.67 kB` | <sup>*102x* </sup>`3,217 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`58.97 kB` |       <sup>-49% </sup>`18.80 kB` |     <sup>*3x* </sup>`105 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`59.88 kB` |       <sup>-47% </sup>`19.30 kB` |    **<sup>🏆 </sup>`31 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`63.01 kB` |       <sup>-47% </sup>`19.53 kB` |    <sup>*13x* </sup>`429 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`63.15 kB` |       <sup>-46% </sup>`19.60 kB` |    <sup>*16x* </sup>`531 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`60.94 kB` |       <sup>-46% </sup>`19.68 kB` | <sup>*191x* </sup>`6,032 ms` |
-----
-| Artifact                                                      | Original size |  Gzip size |
-| :------------------------------------------------------------ | ------------: | ---------: |
-| [**vue v2.6.12**](https://www.npmjs.com/package/vue/v/2.6.12) |   `223.16 kB` | `62.27 kB` |
-
-| Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
-| :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-58% </sup>`94.18 kB`** | **<sup>🏆-50% </sup>`31.19 kB`** |  <sup>*59x* </sup>`2,473 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-57% </sup>`94.91 kB` |       <sup>-50% </sup>`31.25 kB` |  <sup>*34x* </sup>`1,411 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-57% </sup>`94.87 kB` |       <sup>-50% </sup>`31.35 kB` |     <sup>*3x* </sup>`135 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-57% </sup>`95.18 kB` |       <sup>-50% </sup>`31.44 kB` |  <sup>*86x* </sup>`3,593 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-57% </sup>`95.06 kB` |       <sup>-49% </sup>`31.76 kB` |    **<sup>🏆 </sup>`41 ms`** |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |      <sup>-55% </sup>`101.18 kB` |       <sup>-48% </sup>`32.07 kB` |    <sup>*14x* </sup>`611 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |      <sup>-55% </sup>`101.05 kB` |       <sup>-48% </sup>`32.15 kB` |    <sup>*12x* </sup>`537 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-55% </sup>`99.44 kB` |       <sup>-47% </sup>`32.99 kB` | <sup>*152x* </sup>`6,325 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`58.33 kB`** | **<sup>🏆-49% </sup>`18.49 kB`** |  <sup>*74x* </sup>`1,791 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`59.05 kB` |       <sup>-49% </sup>`18.59 kB` |  <sup>*41x* </sup>`1,003 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`59.11 kB` |       <sup>-49% </sup>`18.67 kB` |  <sup>*95x* </sup>`2,286 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`58.97 kB` |       <sup>-49% </sup>`18.80 kB` |      <sup>*3x* </sup>`82 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`59.89 kB` |       <sup>-47% </sup>`19.30 kB` |    **<sup>🏆 </sup>`24 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`63.01 kB` |       <sup>-47% </sup>`19.53 kB` |    <sup>*13x* </sup>`318 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`63.15 kB` |       <sup>-46% </sup>`19.60 kB` |    <sup>*16x* </sup>`397 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`60.94 kB` |       <sup>-46% </sup>`19.68 kB` | <sup>*175x* </sup>`4,213 ms` |
 ----
 | Artifact                                                          | Original size |  Gzip size |
 | :---------------------------------------------------------------- | ------------: | ---------: |
@@ -76,14 +61,29 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`88.83 kB`** | **<sup>🏆-63% </sup>`30.97 kB`** |  <sup>*73x* </sup>`3,379 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-69% </sup>`89.88 kB` |       <sup>-63% </sup>`31.02 kB` |  <sup>*38x* </sup>`1,761 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-69% </sup>`89.35 kB` |       <sup>-63% </sup>`31.09 kB` |     <sup>*4x* </sup>`203 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-67% </sup>`94.25 kB` |       <sup>-63% </sup>`31.58 kB` |    <sup>*13x* </sup>`624 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-67% </sup>`94.55 kB` |       <sup>-63% </sup>`31.69 kB` |    <sup>*15x* </sup>`715 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-68% </sup>`91.92 kB` |       <sup>-63% </sup>`31.73 kB` | <sup>*113x* </sup>`5,230 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-69% </sup>`90.20 kB` |       <sup>-62% </sup>`31.98 kB` |    **<sup>🏆 </sup>`46 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-67% </sup>`96.09 kB` |       <sup>-59% </sup>`34.34 kB` | <sup>*135x* </sup>`6,272 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`88.83 kB`** | **<sup>🏆-63% </sup>`30.97 kB`** |  <sup>*71x* </sup>`2,483 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-69% </sup>`89.88 kB` |       <sup>-63% </sup>`31.02 kB` |  <sup>*37x* </sup>`1,309 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-69% </sup>`89.35 kB` |       <sup>-63% </sup>`31.09 kB` |     <sup>*4x* </sup>`152 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-67% </sup>`94.25 kB` |       <sup>-63% </sup>`31.58 kB` |    <sup>*13x* </sup>`457 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-67% </sup>`94.55 kB` |       <sup>-63% </sup>`31.69 kB` |    <sup>*15x* </sup>`525 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-68% </sup>`91.92 kB` |       <sup>-63% </sup>`31.73 kB` | <sup>*105x* </sup>`3,670 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-69% </sup>`90.20 kB` |       <sup>-62% </sup>`31.98 kB` |    **<sup>🏆 </sup>`35 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-67% </sup>`96.09 kB` |       <sup>-59% </sup>`34.34 kB` | <sup>*137x* </sup>`4,788 ms` |
+----
+| Artifact                                                      | Original size |  Gzip size |
+| :------------------------------------------------------------ | ------------: | ---------: |
+| [**vue v2.6.12**](https://www.npmjs.com/package/vue/v/2.6.12) |   `342.15 kB` | `90.12 kB` |
+
+| Minifier                                                                           |                     Minified size |                   Minzipped size |                         Time |
+| :--------------------------------------------------------------------------------- | --------------------------------: | -------------------------------: | ---------------------------: |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`115.10 kB`** | **<sup>🏆-53% </sup>`42.58 kB`** |  <sup>*76x* </sup>`3,286 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`116.77 kB` |       <sup>-52% </sup>`42.91 kB` |  <sup>*37x* </sup>`1,620 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`116.92 kB` |       <sup>-52% </sup>`43.00 kB` |     <sup>*5x* </sup>`238 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`117.61 kB` |       <sup>-51% </sup>`43.72 kB` |  <sup>*94x* </sup>`4,032 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`118.32 kB` |       <sup>-51% </sup>`44.29 kB` |    **<sup>🏆 </sup>`43 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-63% </sup>`126.39 kB` |       <sup>-51% </sup>`44.47 kB` |    <sup>*12x* </sup>`529 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-63% </sup>`126.58 kB` |       <sup>-50% </sup>`44.64 kB` |    <sup>*14x* </sup>`634 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`120.01 kB` |       <sup>-50% </sup>`45.42 kB` | <sup>*128x* </sup>`5,484 ms` |
 ----
 | Artifact                                                              | Original size |  Gzip size |
 | :-------------------------------------------------------------------- | ------------: | ---------: |
@@ -91,29 +91,29 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-87% </sup>`69.66 kB`** | **<sup>🏆-75% </sup>`24.58 kB`** |  <sup>*71x* </sup>`3,302 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-87% </sup>`71.81 kB` |       <sup>-74% </sup>`25.13 kB` |  <sup>*98x* </sup>`4,594 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-87% </sup>`71.07 kB` |       <sup>-74% </sup>`25.16 kB` |  <sup>*40x* </sup>`1,885 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-86% </sup>`73.89 kB` |       <sup>-74% </sup>`25.18 kB` |     <sup>*6x* </sup>`300 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-86% </sup>`75.44 kB` |       <sup>-73% </sup>`25.89 kB` |    <sup>*14x* </sup>`682 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-87% </sup>`72.49 kB` |       <sup>-73% </sup>`26.14 kB` |    **<sup>🏆 </sup>`46 ms`** |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-86% </sup>`75.67 kB` |       <sup>-73% </sup>`26.17 kB` |    <sup>*16x* </sup>`752 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-86% </sup>`77.39 kB` |       <sup>-73% </sup>`26.25 kB` | <sup>*145x* </sup>`6,745 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-87% </sup>`69.66 kB`** | **<sup>🏆-75% </sup>`24.58 kB`** |  <sup>*67x* </sup>`2,482 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-87% </sup>`71.81 kB` |       <sup>-74% </sup>`25.13 kB` |  <sup>*90x* </sup>`3,336 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-87% </sup>`71.07 kB` |       <sup>-74% </sup>`25.16 kB` |  <sup>*39x* </sup>`1,450 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-86% </sup>`73.89 kB` |       <sup>-74% </sup>`25.18 kB` |     <sup>*6x* </sup>`236 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-86% </sup>`75.44 kB` |       <sup>-73% </sup>`25.89 kB` |    <sup>*13x* </sup>`509 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-87% </sup>`72.49 kB` |       <sup>-73% </sup>`26.14 kB` |    **<sup>🏆 </sup>`37 ms`** |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-86% </sup>`75.67 kB` |       <sup>-73% </sup>`26.17 kB` |    <sup>*15x* </sup>`571 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-86% </sup>`77.39 kB` |       <sup>-73% </sup>`26.25 kB` | <sup>*136x* </sup>`5,000 ms` |
 ----
 | Artifact                                                  | Original size |   Gzip size |
 | :-------------------------------------------------------- | ------------: | ----------: |
 | [**d3 v6.3.1**](https://www.npmjs.com/package/d3/v/6.3.1) |   `555.77 kB` | `130.55 kB` |
 
-| Minifier                                                                           |                     Minified size |                   Minzipped size |                          Time |
-| :--------------------------------------------------------------------------------- | --------------------------------: | -------------------------------: | ----------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-52% </sup>`265.30 kB`** | **<sup>🏆-33% </sup>`87.23 kB`** |   <sup>*95x* </sup>`9,626 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-52% </sup>`267.99 kB` |       <sup>-33% </sup>`87.92 kB` |   <sup>*45x* </sup>`4,606 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-50% </sup>`276.12 kB` |       <sup>-32% </sup>`88.63 kB` |   <sup>*13x* </sup>`1,407 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-50% </sup>`276.47 kB` |       <sup>-32% </sup>`89.16 kB` |   <sup>*19x* </sup>`1,941 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-51% </sup>`270.88 kB` |       <sup>-31% </sup>`90.05 kB` |   <sup>*12x* </sup>`1,240 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-51% </sup>`270.19 kB` |       <sup>-31% </sup>`90.63 kB` |    **<sup>🏆 </sup>`101 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-45% </sup>`306.40 kB` |      <sup>-22% </sup>`101.94 kB` | <sup>*107x* </sup>`10,916 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                — |                             — |
+| Minifier                                                                           |                     Minified size |                   Minzipped size |                         Time |
+| :--------------------------------------------------------------------------------- | --------------------------------: | -------------------------------: | ---------------------------: |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-52% </sup>`265.30 kB`** | **<sup>🏆-33% </sup>`87.23 kB`** |  <sup>*87x* </sup>`6,845 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-52% </sup>`267.99 kB` |       <sup>-33% </sup>`87.92 kB` |  <sup>*42x* </sup>`3,307 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-50% </sup>`276.12 kB` |       <sup>-32% </sup>`88.63 kB` |  <sup>*13x* </sup>`1,037 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-50% </sup>`276.47 kB` |       <sup>-32% </sup>`89.16 kB` |  <sup>*17x* </sup>`1,409 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-51% </sup>`270.88 kB` |       <sup>-31% </sup>`90.05 kB` |  <sup>*12x* </sup>`1,006 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-51% </sup>`270.19 kB` |       <sup>-31% </sup>`90.63 kB` |    **<sup>🏆 </sup>`78 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-45% </sup>`306.40 kB` |      <sup>-22% </sup>`101.94 kB` | <sup>*103x* </sup>`8,072 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                — |                            — |
 ----
 | Artifact                                                          | Original size |   Gzip size |
 | :---------------------------------------------------------------- | ------------: | ----------: |
@@ -121,12 +121,12 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-54% </sup>`410.97 kB`** | **<sup>🏆-36% </sup>`116.47 kB`** |  <sup>*74x* </sup>`7,368 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-54% </sup>`414.42 kB` |       <sup>-35% </sup>`116.65 kB` |  <sup>*40x* </sup>`3,969 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-52% </sup>`428.63 kB` |       <sup>-35% </sup>`117.53 kB` |  <sup>*17x* </sup>`1,701 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-53% </sup>`427.11 kB` |       <sup>-35% </sup>`117.61 kB` |  <sup>*14x* </sup>`1,412 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-54% </sup>`415.58 kB` |       <sup>-34% </sup>`119.42 kB` |    **<sup>🏆 </sup>`98 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-52% </sup>`429.18 kB` |       <sup>-30% </sup>`127.06 kB` | <sup>*100x* </sup>`9,908 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-54% </sup>`410.97 kB`** | **<sup>🏆-36% </sup>`116.47 kB`** |  <sup>*72x* </sup>`5,312 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-54% </sup>`414.42 kB` |       <sup>-35% </sup>`116.65 kB` |  <sup>*40x* </sup>`2,941 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-52% </sup>`428.63 kB` |       <sup>-35% </sup>`117.53 kB` |  <sup>*17x* </sup>`1,258 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-53% </sup>`427.11 kB` |       <sup>-35% </sup>`117.61 kB` |  <sup>*14x* </sup>`1,076 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-54% </sup>`415.58 kB` |       <sup>-34% </sup>`119.42 kB` |    **<sup>🏆 </sup>`73 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-52% </sup>`429.18 kB` |       <sup>-30% </sup>`127.06 kB` | <sup>*102x* </sup>`7,554 ms` |
 | [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                            — |
 | [swc](/lib/minifiers/swc.ts) <sub>_Failed_</sub>                                   |                                 — |                                 — |                            — |
 ----
@@ -136,14 +136,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                          Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ----------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-48% </sup>`644.18 kB`** | **<sup>🏆-36% </sup>`158.60 kB`** |  <sup>*67x* </sup>`11,108 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-48% </sup>`653.37 kB` |       <sup>-36% </sup>`159.13 kB` |   <sup>*34x* </sup>`5,588 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-48% </sup>`649.78 kB` |       <sup>-36% </sup>`160.07 kB` |    <sup>*7x* </sup>`1,188 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-48% </sup>`645.34 kB` |       <sup>-35% </sup>`161.44 kB` | <sup>*121x* </sup>`19,973 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-46% </sup>`675.43 kB` |       <sup>-35% </sup>`162.89 kB` |   <sup>*12x* </sup>`1,995 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-46% </sup>`675.60 kB` |       <sup>-35% </sup>`162.91 kB` |   <sup>*14x* </sup>`2,433 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-48% </sup>`646.98 kB` |       <sup>-34% </sup>`163.24 kB` |    **<sup>🏆 </sup>`164 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-47% </sup>`660.12 kB` |       <sup>-33% </sup>`167.10 kB` |  <sup>*80x* </sup>`13,255 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-48% </sup>`644.18 kB`** | **<sup>🏆-36% </sup>`158.60 kB`** |   <sup>*62x* </sup>`8,053 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-48% </sup>`653.37 kB` |       <sup>-36% </sup>`159.13 kB` |   <sup>*32x* </sup>`4,173 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-48% </sup>`649.78 kB` |       <sup>-36% </sup>`160.07 kB` |    <sup>*8x* </sup>`1,041 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-48% </sup>`645.34 kB` |       <sup>-35% </sup>`161.44 kB` | <sup>*105x* </sup>`13,663 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-46% </sup>`675.43 kB` |       <sup>-35% </sup>`162.89 kB` |   <sup>*11x* </sup>`1,494 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-46% </sup>`675.60 kB` |       <sup>-35% </sup>`162.91 kB` |   <sup>*13x* </sup>`1,807 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-48% </sup>`646.98 kB` |       <sup>-34% </sup>`163.24 kB` |    **<sup>🏆 </sup>`129 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-47% </sup>`660.12 kB` |       <sup>-33% </sup>`167.10 kB` |   <sup>*75x* </sup>`9,824 ms` |
 ----
 | Artifact                                                              | Original size |   Gzip size |
 | :-------------------------------------------------------------------- | ------------: | ----------: |
@@ -151,13 +151,13 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ---------------------------: |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`715.74 kB` | **<sup>🏆-49% </sup>`159.01 kB`** |  <sup>*34x* </sup>`7,912 ms` |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`707.17 kB`** |       <sup>-49% </sup>`159.20 kB` | <sup>*68x* </sup>`15,716 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`716.98 kB` |       <sup>-48% </sup>`160.99 kB` |   <sup>*6x* </sup>`1,512 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`759.34 kB` |       <sup>-47% </sup>`166.63 kB` |  <sup>*14x* </sup>`3,245 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`756.58 kB` |       <sup>-46% </sup>`167.61 kB` |  <sup>*11x* </sup>`2,729 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`724.29 kB` |       <sup>-42% </sup>`180.44 kB` |   **<sup>🏆 </sup>`229 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`727.13 kB` |       <sup>-42% </sup>`180.82 kB` | <sup>*67x* </sup>`15,479 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`715.74 kB` | **<sup>🏆-49% </sup>`159.01 kB`** |  <sup>*34x* </sup>`5,841 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`707.17 kB`** |       <sup>-49% </sup>`159.20 kB` | <sup>*66x* </sup>`11,373 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`716.98 kB` |       <sup>-48% </sup>`160.99 kB` |   <sup>*7x* </sup>`1,234 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`759.34 kB` |       <sup>-47% </sup>`166.63 kB` |  <sup>*13x* </sup>`2,339 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`756.58 kB` |       <sup>-46% </sup>`167.61 kB` |  <sup>*11x* </sup>`1,982 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`724.29 kB` |       <sup>-42% </sup>`180.44 kB` |   **<sup>🏆 </sup>`171 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`727.13 kB` |       <sup>-42% </sup>`180.82 kB` | <sup>*67x* </sup>`11,478 ms` |
 | [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                            — |
 ----
 | Artifact                                                            | Original size |   Gzip size |
@@ -166,12 +166,12 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ---------------------------: |
-| [terser](/lib/minifiers/terser.ts)                                                 |         <sup>-69% </sup>`1.00 MB` | **<sup>🏆-53% </sup>`322.12 kB`** | <sup>*34x* </sup>`11,660 ms` |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`983.77 kB`** |       <sup>-53% </sup>`326.09 kB` | <sup>*76x* </sup>`26,224 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-69% </sup>`997.97 kB` |       <sup>-52% </sup>`329.90 kB` | <sup>*61x* </sup>`21,071 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |         <sup>-66% </sup>`1.07 MB` |       <sup>-52% </sup>`330.73 kB` |  <sup>*15x* </sup>`5,281 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |         <sup>-68% </sup>`1.01 MB` |       <sup>-52% </sup>`331.66 kB` |   **<sup>🏆 </sup>`342 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |         <sup>-67% </sup>`1.07 MB` |       <sup>-52% </sup>`331.66 kB` |  <sup>*10x* </sup>`3,526 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |         <sup>-69% </sup>`1.00 MB` | **<sup>🏆-53% </sup>`322.12 kB`** |  <sup>*31x* </sup>`8,514 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`983.77 kB`** |       <sup>-53% </sup>`326.09 kB` | <sup>*68x* </sup>`18,842 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-69% </sup>`997.97 kB` |       <sup>-52% </sup>`329.90 kB` | <sup>*58x* </sup>`16,124 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |         <sup>-66% </sup>`1.07 MB` |       <sup>-52% </sup>`330.73 kB` |  <sup>*14x* </sup>`3,954 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |         <sup>-68% </sup>`1.01 MB` |       <sup>-52% </sup>`331.66 kB` |   **<sup>🏆 </sup>`274 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |         <sup>-67% </sup>`1.07 MB` |       <sup>-52% </sup>`331.66 kB` |   <sup>*9x* </sup>`2,645 ms` |
 | [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                            — |
 | [swc](/lib/minifiers/swc.ts) <sub>_Failed_</sub>                                   |                                 — |                                 — |                            — |
 ----
@@ -179,16 +179,16 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 4, 2021<!-- lastUpdate
 | :-------------------------------------------------------------- | ------------: | ----------: |
 | [**antd v4.16.1**](https://www.npmjs.com/package/antd/v/4.16.1) |     `6.69 MB` | `833.49 kB` |
 
-| Minifier                                                                           |                   Minified size |                    Minzipped size |                         Time |
-| :--------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`2.23 MB`** | **<sup>🏆-45% </sup>`458.73 kB`** | <sup>*45x* </sup>`28,590 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`2.25 MB` |       <sup>-45% </sup>`461.42 kB` | <sup>*21x* </sup>`13,350 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`2.28 MB` |       <sup>-44% </sup>`463.44 kB` |   <sup>*5x* </sup>`3,701 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`2.43 MB` |       <sup>-42% </sup>`479.86 kB` |   <sup>*9x* </sup>`6,208 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`2.42 MB` |       <sup>-42% </sup>`482.98 kB` |   <sup>*7x* </sup>`5,041 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`2.27 MB` |       <sup>-41% </sup>`490.34 kB` | <sup>*55x* </sup>`34,995 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`2.31 MB` |       <sup>-41% </sup>`491.09 kB` |   **<sup>🏆 </sup>`631 ms`** |
-| [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                               — |                                 — |                            — |
+| Minifier                                                                           |                   Minified size |                    Minzipped size |                          Time |
+| :--------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | ----------------------------: |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`2.23 MB`** | **<sup>🏆-45% </sup>`458.73 kB`** |  <sup>*46x* </sup>`20,005 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`2.25 MB` |       <sup>-45% </sup>`461.42 kB` |   <sup>*22x* </sup>`9,701 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`2.28 MB` |       <sup>-44% </sup>`463.44 kB` |    <sup>*6x* </sup>`2,828 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`2.28 MB` |       <sup>-44% </sup>`466.32 kB` | <sup>*129x* </sup>`55,195 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`2.43 MB` |       <sup>-42% </sup>`479.86 kB` |   <sup>*10x* </sup>`4,498 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`2.42 MB` |       <sup>-42% </sup>`482.98 kB` |    <sup>*8x* </sup>`3,684 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`2.27 MB` |       <sup>-41% </sup>`490.34 kB` |  <sup>*42x* </sup>`17,931 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`2.31 MB` |       <sup>-41% </sup>`491.09 kB` |    **<sup>🏆 </sup>`427 ms`** |
 <!-- benchmarks:end -->
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -31,14 +31,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                  Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | ------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-68% </sup>`22.83 kB`** | **<sup>🏆-58% </sup>`8.21 kB`** |    <sup>*43x* </sup>`757 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-68% </sup>`23.12 kB` |       <sup>-57% </sup>`8.29 kB` |    <sup>*21x* </sup>`376 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-68% </sup>`23.10 kB` |       <sup>-57% </sup>`8.33 kB` |      <sup>*1x* </sup>`32 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-67% </sup>`23.53 kB` |       <sup>-57% </sup>`8.38 kB` |  <sup>*57x* </sup>`1,001 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-67% </sup>`23.73 kB` |       <sup>-56% </sup>`8.55 kB` |    **<sup>🏆 </sup>`17 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`25.06 kB` |       <sup>-56% </sup>`8.65 kB` |     <sup>*7x* </sup>`138 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-65% </sup>`25.08 kB` |       <sup>-55% </sup>`8.72 kB` |    <sup>*10x* </sup>`179 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-55% </sup>`32.76 kB` |      <sup>-43% </sup>`11.10 kB` | <sup>*266x* </sup>`4,656 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-68% </sup>`22.83 kB`** | **<sup>🏆-58% </sup>`8.21 kB`** |    <sup>*49x* </sup>`827 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-68% </sup>`23.12 kB` |       <sup>-57% </sup>`8.29 kB` |    <sup>*23x* </sup>`394 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-68% </sup>`23.10 kB` |       <sup>-57% </sup>`8.33 kB` |      <sup>*1x* </sup>`33 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-67% </sup>`23.53 kB` |       <sup>-57% </sup>`8.38 kB` |  <sup>*65x* </sup>`1,098 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-67% </sup>`23.73 kB` |       <sup>-56% </sup>`8.56 kB` |    **<sup>🏆 </sup>`17 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`25.06 kB` |       <sup>-56% </sup>`8.65 kB` |     <sup>*8x* </sup>`148 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-65% </sup>`25.08 kB` |       <sup>-55% </sup>`8.72 kB` |    <sup>*11x* </sup>`186 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-55% </sup>`32.76 kB` |      <sup>-43% </sup>`11.10 kB` | <sup>*279x* </sup>`4,718 ms` |
 ----
 | Artifact                                                            | Original size |  Gzip size |
 | :------------------------------------------------------------------ | ------------: | ---------: |
@@ -46,14 +46,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`58.33 kB`** | **<sup>🏆-49% </sup>`18.49 kB`** |  <sup>*74x* </sup>`1,791 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`59.05 kB` |       <sup>-49% </sup>`18.59 kB` |  <sup>*41x* </sup>`1,003 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`59.11 kB` |       <sup>-49% </sup>`18.67 kB` |  <sup>*95x* </sup>`2,286 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`58.97 kB` |       <sup>-49% </sup>`18.80 kB` |      <sup>*3x* </sup>`82 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`59.89 kB` |       <sup>-47% </sup>`19.30 kB` |    **<sup>🏆 </sup>`24 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`63.01 kB` |       <sup>-47% </sup>`19.53 kB` |    <sup>*13x* </sup>`318 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`63.15 kB` |       <sup>-46% </sup>`19.60 kB` |    <sup>*16x* </sup>`397 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`60.94 kB` |       <sup>-46% </sup>`19.68 kB` | <sup>*175x* </sup>`4,213 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`58.33 kB`** | **<sup>🏆-49% </sup>`18.49 kB`** |  <sup>*76x* </sup>`1,881 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`59.05 kB` |       <sup>-49% </sup>`18.59 kB` |  <sup>*42x* </sup>`1,040 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`59.11 kB` |       <sup>-49% </sup>`18.67 kB` | <sup>*104x* </sup>`2,560 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`58.97 kB` |       <sup>-49% </sup>`18.80 kB` |      <sup>*3x* </sup>`87 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`59.88 kB` |       <sup>-47% </sup>`19.30 kB` |    **<sup>🏆 </sup>`25 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`63.01 kB` |       <sup>-47% </sup>`19.53 kB` |    <sup>*13x* </sup>`323 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`63.15 kB` |       <sup>-46% </sup>`19.60 kB` |    <sup>*17x* </sup>`426 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`60.94 kB` |       <sup>-46% </sup>`19.68 kB` | <sup>*190x* </sup>`4,666 ms` |
 ----
 | Artifact                                                          | Original size |  Gzip size |
 | :---------------------------------------------------------------- | ------------: | ---------: |
@@ -61,14 +61,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`88.83 kB`** | **<sup>🏆-63% </sup>`30.97 kB`** |  <sup>*71x* </sup>`2,483 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-69% </sup>`89.88 kB` |       <sup>-63% </sup>`31.02 kB` |  <sup>*37x* </sup>`1,309 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-69% </sup>`89.35 kB` |       <sup>-63% </sup>`31.09 kB` |     <sup>*4x* </sup>`152 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-67% </sup>`94.25 kB` |       <sup>-63% </sup>`31.58 kB` |    <sup>*13x* </sup>`457 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-67% </sup>`94.55 kB` |       <sup>-63% </sup>`31.69 kB` |    <sup>*15x* </sup>`525 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-68% </sup>`91.92 kB` |       <sup>-63% </sup>`31.73 kB` | <sup>*105x* </sup>`3,670 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-69% </sup>`90.20 kB` |       <sup>-62% </sup>`31.98 kB` |    **<sup>🏆 </sup>`35 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-67% </sup>`96.09 kB` |       <sup>-59% </sup>`34.34 kB` | <sup>*137x* </sup>`4,788 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`88.83 kB`** | **<sup>🏆-63% </sup>`30.97 kB`** |  <sup>*77x* </sup>`2,644 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-69% </sup>`89.88 kB` |       <sup>-63% </sup>`31.02 kB` |  <sup>*40x* </sup>`1,367 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-69% </sup>`89.35 kB` |       <sup>-63% </sup>`31.09 kB` |     <sup>*4x* </sup>`146 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-67% </sup>`94.25 kB` |       <sup>-63% </sup>`31.58 kB` |    <sup>*13x* </sup>`475 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-67% </sup>`94.55 kB` |       <sup>-63% </sup>`31.69 kB` |    <sup>*16x* </sup>`554 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-68% </sup>`91.92 kB` |       <sup>-63% </sup>`31.73 kB` | <sup>*122x* </sup>`4,176 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-69% </sup>`90.20 kB` |       <sup>-62% </sup>`31.98 kB` |    **<sup>🏆 </sup>`34 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-67% </sup>`96.09 kB` |       <sup>-59% </sup>`34.34 kB` | <sup>*146x* </sup>`4,970 ms` |
 ----
 | Artifact                                                      | Original size |  Gzip size |
 | :------------------------------------------------------------ | ------------: | ---------: |
@@ -76,14 +76,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`115.10 kB`** | **<sup>🏆-53% </sup>`42.58 kB`** |  <sup>*76x* </sup>`3,286 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`116.77 kB` |       <sup>-52% </sup>`42.91 kB` |  <sup>*37x* </sup>`1,620 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`116.92 kB` |       <sup>-52% </sup>`43.00 kB` |     <sup>*5x* </sup>`238 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`117.61 kB` |       <sup>-51% </sup>`43.72 kB` |  <sup>*94x* </sup>`4,032 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`118.32 kB` |       <sup>-51% </sup>`44.29 kB` |    **<sup>🏆 </sup>`43 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-63% </sup>`126.39 kB` |       <sup>-51% </sup>`44.47 kB` |    <sup>*12x* </sup>`529 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-63% </sup>`126.58 kB` |       <sup>-50% </sup>`44.64 kB` |    <sup>*14x* </sup>`634 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`120.01 kB` |       <sup>-50% </sup>`45.42 kB` | <sup>*128x* </sup>`5,484 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-66% </sup>`115.10 kB`** | **<sup>🏆-53% </sup>`42.58 kB`** |  <sup>*78x* </sup>`3,403 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`116.77 kB` |       <sup>-52% </sup>`42.91 kB` |  <sup>*38x* </sup>`1,667 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`116.92 kB` |       <sup>-52% </sup>`43.00 kB` |     <sup>*5x* </sup>`231 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`117.61 kB` |       <sup>-51% </sup>`43.72 kB` | <sup>*105x* </sup>`4,542 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`118.31 kB` |       <sup>-51% </sup>`44.29 kB` |    **<sup>🏆 </sup>`43 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-63% </sup>`126.39 kB` |       <sup>-51% </sup>`44.47 kB` |    <sup>*11x* </sup>`511 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-63% </sup>`126.58 kB` |       <sup>-50% </sup>`44.64 kB` |    <sup>*14x* </sup>`638 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-65% </sup>`120.01 kB` |       <sup>-50% </sup>`45.42 kB` | <sup>*137x* </sup>`5,947 ms` |
 ----
 | Artifact                                                              | Original size |  Gzip size |
 | :-------------------------------------------------------------------- | ------------: | ---------: |
@@ -91,14 +91,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                    Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | -------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-87% </sup>`69.66 kB`** | **<sup>🏆-75% </sup>`24.58 kB`** |  <sup>*67x* </sup>`2,482 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-87% </sup>`71.81 kB` |       <sup>-74% </sup>`25.13 kB` |  <sup>*90x* </sup>`3,336 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-87% </sup>`71.07 kB` |       <sup>-74% </sup>`25.16 kB` |  <sup>*39x* </sup>`1,450 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-86% </sup>`73.89 kB` |       <sup>-74% </sup>`25.18 kB` |     <sup>*6x* </sup>`236 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-86% </sup>`75.44 kB` |       <sup>-73% </sup>`25.89 kB` |    <sup>*13x* </sup>`509 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-87% </sup>`69.66 kB`** | **<sup>🏆-75% </sup>`24.58 kB`** |  <sup>*68x* </sup>`2,551 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-87% </sup>`71.81 kB` |       <sup>-74% </sup>`25.13 kB` |  <sup>*94x* </sup>`3,542 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-87% </sup>`71.07 kB` |       <sup>-74% </sup>`25.16 kB` |  <sup>*38x* </sup>`1,434 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-86% </sup>`73.89 kB` |       <sup>-74% </sup>`25.18 kB` |     <sup>*6x* </sup>`228 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-86% </sup>`75.44 kB` |       <sup>-73% </sup>`25.89 kB` |    <sup>*13x* </sup>`494 ms` |
 | [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-87% </sup>`72.49 kB` |       <sup>-73% </sup>`26.14 kB` |    **<sup>🏆 </sup>`37 ms`** |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-86% </sup>`75.67 kB` |       <sup>-73% </sup>`26.17 kB` |    <sup>*15x* </sup>`571 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-86% </sup>`77.39 kB` |       <sup>-73% </sup>`26.25 kB` | <sup>*136x* </sup>`5,000 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-86% </sup>`75.67 kB` |       <sup>-73% </sup>`26.17 kB` |    <sup>*15x* </sup>`578 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-86% </sup>`77.39 kB` |       <sup>-73% </sup>`26.25 kB` | <sup>*135x* </sup>`5,047 ms` |
 ----
 | Artifact                                                  | Original size |   Gzip size |
 | :-------------------------------------------------------- | ------------: | ----------: |
@@ -106,29 +106,29 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                   Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | -------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-52% </sup>`265.30 kB`** | **<sup>🏆-33% </sup>`87.23 kB`** |  <sup>*87x* </sup>`6,845 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-52% </sup>`267.99 kB` |       <sup>-33% </sup>`87.92 kB` |  <sup>*42x* </sup>`3,307 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-50% </sup>`276.12 kB` |       <sup>-32% </sup>`88.63 kB` |  <sup>*13x* </sup>`1,037 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-50% </sup>`276.47 kB` |       <sup>-32% </sup>`89.16 kB` |  <sup>*17x* </sup>`1,409 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-51% </sup>`270.88 kB` |       <sup>-31% </sup>`90.05 kB` |  <sup>*12x* </sup>`1,006 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-51% </sup>`270.19 kB` |       <sup>-31% </sup>`90.63 kB` |    **<sup>🏆 </sup>`78 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-45% </sup>`306.40 kB` |      <sup>-22% </sup>`101.94 kB` | <sup>*103x* </sup>`8,072 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-52% </sup>`265.30 kB`** | **<sup>🏆-33% </sup>`87.23 kB`** |  <sup>*98x* </sup>`7,372 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-52% </sup>`267.99 kB` |       <sup>-33% </sup>`87.92 kB` |  <sup>*46x* </sup>`3,467 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-50% </sup>`276.12 kB` |       <sup>-32% </sup>`88.63 kB` |  <sup>*14x* </sup>`1,083 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-50% </sup>`276.47 kB` |       <sup>-32% </sup>`89.16 kB` |  <sup>*19x* </sup>`1,482 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-51% </sup>`270.88 kB` |       <sup>-31% </sup>`90.05 kB` |    <sup>*12x* </sup>`907 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-51% </sup>`270.19 kB` |       <sup>-31% </sup>`90.63 kB` |    **<sup>🏆 </sup>`75 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-45% </sup>`306.40 kB` |      <sup>-22% </sup>`101.94 kB` | <sup>*114x* </sup>`8,580 ms` |
 | [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                — |                            — |
 ----
 | Artifact                                                          | Original size |   Gzip size |
 | :---------------------------------------------------------------- | ------------: | ----------: |
 | [**terser v5.9.0**](https://www.npmjs.com/package/terser/v/5.9.0) |   `900.82 kB` | `180.72 kB` |
 
-| Minifier                                                                           |                     Minified size |                    Minzipped size |                         Time |
-| :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ---------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-54% </sup>`410.97 kB`** | **<sup>🏆-36% </sup>`116.47 kB`** |  <sup>*72x* </sup>`5,312 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-54% </sup>`414.42 kB` |       <sup>-35% </sup>`116.65 kB` |  <sup>*40x* </sup>`2,941 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-52% </sup>`428.63 kB` |       <sup>-35% </sup>`117.53 kB` |  <sup>*17x* </sup>`1,258 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-53% </sup>`427.11 kB` |       <sup>-35% </sup>`117.61 kB` |  <sup>*14x* </sup>`1,076 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-54% </sup>`415.58 kB` |       <sup>-34% </sup>`119.42 kB` |    **<sup>🏆 </sup>`73 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-52% </sup>`429.18 kB` |       <sup>-30% </sup>`127.06 kB` | <sup>*102x* </sup>`7,554 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                            — |
-| [swc](/lib/minifiers/swc.ts) <sub>_Failed_</sub>                                   |                                 — |                                 — |                            — |
+| Minifier                                                                           |                     Minified size |                    Minzipped size |                        Time |
+| :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | --------------------------: |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-54% </sup>`410.97 kB`** | **<sup>🏆-36% </sup>`116.47 kB`** | <sup>*79x* </sup>`5,842 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-54% </sup>`414.42 kB` |       <sup>-35% </sup>`116.65 kB` | <sup>*42x* </sup>`3,132 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-52% </sup>`428.63 kB` |       <sup>-35% </sup>`117.53 kB` | <sup>*17x* </sup>`1,318 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-53% </sup>`427.11 kB` |       <sup>-35% </sup>`117.61 kB` | <sup>*14x* </sup>`1,109 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-54% </sup>`415.58 kB` |       <sup>-34% </sup>`119.42 kB` |   **<sup>🏆 </sup>`74 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-52% </sup>`429.18 kB` |       <sup>-30% </sup>`127.06 kB` | <sup>*99x* </sup>`7,351 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                           — |
+| [swc](/lib/minifiers/swc.ts) <sub>_Failed_</sub>                                   |                                 — |                                 — |                           — |
 ----
 | Artifact                                                            | Original size |   Gzip size |
 | :------------------------------------------------------------------ | ------------: | ----------: |
@@ -136,14 +136,14 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                          Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ----------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-48% </sup>`644.18 kB`** | **<sup>🏆-36% </sup>`158.60 kB`** |   <sup>*62x* </sup>`8,053 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-48% </sup>`653.37 kB` |       <sup>-36% </sup>`159.13 kB` |   <sup>*32x* </sup>`4,173 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-48% </sup>`649.78 kB` |       <sup>-36% </sup>`160.07 kB` |    <sup>*8x* </sup>`1,041 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-48% </sup>`645.34 kB` |       <sup>-35% </sup>`161.44 kB` | <sup>*105x* </sup>`13,663 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-46% </sup>`675.43 kB` |       <sup>-35% </sup>`162.89 kB` |   <sup>*11x* </sup>`1,494 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-46% </sup>`675.60 kB` |       <sup>-35% </sup>`162.91 kB` |   <sup>*13x* </sup>`1,807 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-48% </sup>`646.98 kB` |       <sup>-34% </sup>`163.24 kB` |    **<sup>🏆 </sup>`129 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-47% </sup>`660.12 kB` |       <sup>-33% </sup>`167.10 kB` |   <sup>*75x* </sup>`9,824 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-48% </sup>`644.18 kB`** | **<sup>🏆-36% </sup>`158.60 kB`** |   <sup>*73x* </sup>`8,779 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-48% </sup>`653.37 kB` |       <sup>-36% </sup>`159.13 kB` |   <sup>*36x* </sup>`4,392 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-48% </sup>`649.78 kB` |       <sup>-36% </sup>`160.07 kB` |      <sup>*7x* </sup>`896 ms` |
+| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-48% </sup>`645.34 kB` |       <sup>-35% </sup>`161.44 kB` | <sup>*131x* </sup>`15,842 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-46% </sup>`675.43 kB` |       <sup>-35% </sup>`162.89 kB` |   <sup>*13x* </sup>`1,594 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-46% </sup>`675.60 kB` |       <sup>-35% </sup>`162.91 kB` |   <sup>*15x* </sup>`1,888 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-48% </sup>`646.98 kB` |       <sup>-34% </sup>`163.24 kB` |    **<sup>🏆 </sup>`120 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-47% </sup>`660.12 kB` |       <sup>-33% </sup>`167.10 kB` |  <sup>*84x* </sup>`10,164 ms` |
 ----
 | Artifact                                                              | Original size |   Gzip size |
 | :-------------------------------------------------------------------- | ------------: | ----------: |
@@ -151,13 +151,13 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ---------------------------: |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`715.74 kB` | **<sup>🏆-49% </sup>`159.01 kB`** |  <sup>*34x* </sup>`5,841 ms` |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`707.17 kB`** |       <sup>-49% </sup>`159.20 kB` | <sup>*66x* </sup>`11,373 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`716.98 kB` |       <sup>-48% </sup>`160.99 kB` |   <sup>*7x* </sup>`1,234 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`759.34 kB` |       <sup>-47% </sup>`166.63 kB` |  <sup>*13x* </sup>`2,339 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`756.58 kB` |       <sup>-46% </sup>`167.61 kB` |  <sup>*11x* </sup>`1,982 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`724.29 kB` |       <sup>-42% </sup>`180.44 kB` |   **<sup>🏆 </sup>`171 ms`** |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`727.13 kB` |       <sup>-42% </sup>`180.82 kB` | <sup>*67x* </sup>`11,478 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`715.74 kB` | **<sup>🏆-49% </sup>`159.01 kB`** |  <sup>*36x* </sup>`6,131 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`707.17 kB`** |       <sup>-49% </sup>`159.20 kB` | <sup>*73x* </sup>`12,431 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`716.98 kB` |       <sup>-48% </sup>`160.99 kB` |   <sup>*6x* </sup>`1,130 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`759.34 kB` |       <sup>-47% </sup>`166.63 kB` |  <sup>*14x* </sup>`2,459 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-65% </sup>`756.58 kB` |       <sup>-46% </sup>`167.61 kB` |  <sup>*12x* </sup>`2,107 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-66% </sup>`724.29 kB` |       <sup>-42% </sup>`180.44 kB` |   **<sup>🏆 </sup>`170 ms`** |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`727.13 kB` |       <sup>-42% </sup>`180.82 kB` | <sup>*68x* </sup>`11,540 ms` |
 | [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                            — |
 ----
 | Artifact                                                            | Original size |   Gzip size |
@@ -166,12 +166,12 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 
 | Minifier                                                                           |                     Minified size |                    Minzipped size |                         Time |
 | :--------------------------------------------------------------------------------- | --------------------------------: | --------------------------------: | ---------------------------: |
-| [terser](/lib/minifiers/terser.ts)                                                 |         <sup>-69% </sup>`1.00 MB` | **<sup>🏆-53% </sup>`322.12 kB`** |  <sup>*31x* </sup>`8,514 ms` |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`983.77 kB`** |       <sup>-53% </sup>`326.09 kB` | <sup>*68x* </sup>`18,842 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-69% </sup>`997.97 kB` |       <sup>-52% </sup>`329.90 kB` | <sup>*58x* </sup>`16,124 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |         <sup>-66% </sup>`1.07 MB` |       <sup>-52% </sup>`330.73 kB` |  <sup>*14x* </sup>`3,954 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |         <sup>-68% </sup>`1.01 MB` |       <sup>-52% </sup>`331.66 kB` |   **<sup>🏆 </sup>`274 ms`** |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |         <sup>-67% </sup>`1.07 MB` |       <sup>-52% </sup>`331.66 kB` |   <sup>*9x* </sup>`2,645 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |         <sup>-69% </sup>`1.00 MB` | **<sup>🏆-53% </sup>`322.12 kB`** |  <sup>*34x* </sup>`9,230 ms` |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-69% </sup>`983.77 kB`** |       <sup>-53% </sup>`326.09 kB` | <sup>*79x* </sup>`21,147 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-69% </sup>`997.97 kB` |       <sup>-52% </sup>`329.90 kB` | <sup>*65x* </sup>`17,415 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |         <sup>-66% </sup>`1.07 MB` |       <sup>-52% </sup>`330.73 kB` |  <sup>*15x* </sup>`4,261 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |         <sup>-68% </sup>`1.01 MB` |       <sup>-52% </sup>`331.66 kB` |   **<sup>🏆 </sup>`267 ms`** |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |         <sup>-67% </sup>`1.07 MB` |       <sup>-52% </sup>`331.66 kB` |  <sup>*10x* </sup>`2,806 ms` |
 | [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                                 — |                                 — |                            — |
 | [swc](/lib/minifiers/swc.ts) <sub>_Failed_</sub>                                   |                                 — |                                 — |                            — |
 ----
@@ -179,16 +179,16 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Nov 5, 2021<!-- lastUpdate
 | :-------------------------------------------------------------- | ------------: | ----------: |
 | [**antd v4.16.1**](https://www.npmjs.com/package/antd/v/4.16.1) |     `6.69 MB` | `833.49 kB` |
 
-| Minifier                                                                           |                   Minified size |                    Minzipped size |                          Time |
-| :--------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | ----------------------------: |
-| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`2.23 MB`** | **<sup>🏆-45% </sup>`458.73 kB`** |  <sup>*46x* </sup>`20,005 ms` |
-| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`2.25 MB` |       <sup>-45% </sup>`461.42 kB` |   <sup>*22x* </sup>`9,701 ms` |
-| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`2.28 MB` |       <sup>-44% </sup>`463.44 kB` |    <sup>*6x* </sup>`2,828 ms` |
-| [babel-minify](/lib/minifiers/babel-minify.ts)                                     |       <sup>-66% </sup>`2.28 MB` |       <sup>-44% </sup>`466.32 kB` | <sup>*129x* </sup>`55,195 ms` |
-| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`2.43 MB` |       <sup>-42% </sup>`479.86 kB` |   <sup>*10x* </sup>`4,498 ms` |
-| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`2.42 MB` |       <sup>-42% </sup>`482.98 kB` |    <sup>*8x* </sup>`3,684 ms` |
-| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`2.27 MB` |       <sup>-41% </sup>`490.34 kB` |  <sup>*42x* </sup>`17,931 ms` |
-| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`2.31 MB` |       <sup>-41% </sup>`491.09 kB` |    **<sup>🏆 </sup>`427 ms`** |
+| Minifier                                                                           |                   Minified size |                    Minzipped size |                         Time |
+| :--------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | ---------------------------: |
+| [uglify-js](/lib/minifiers/uglify-js.ts)                                           | **<sup>🏆-67% </sup>`2.23 MB`** | **<sup>🏆-45% </sup>`458.73 kB`** | <sup>*46x* </sup>`23,728 ms` |
+| [terser](/lib/minifiers/terser.ts)                                                 |       <sup>-66% </sup>`2.25 MB` |       <sup>-45% </sup>`461.42 kB` | <sup>*21x* </sup>`11,035 ms` |
+| [swc](/lib/minifiers/swc.ts)                                                       |       <sup>-66% </sup>`2.28 MB` |       <sup>-44% </sup>`463.44 kB` |   <sup>*5x* </sup>`2,974 ms` |
+| [terser.no-compress](/lib/minifiers/terser.no-compress.ts)                         |       <sup>-64% </sup>`2.43 MB` |       <sup>-42% </sup>`479.86 kB` |   <sup>*9x* </sup>`4,839 ms` |
+| [uglify-js.no-compress](/lib/minifiers/uglify-js.no-compress.ts)                   |       <sup>-64% </sup>`2.42 MB` |       <sup>-42% </sup>`482.98 kB` |   <sup>*8x* </sup>`4,140 ms` |
+| [google-closure-compiler.simple](/lib/minifiers/google-closure-compiler.simple.ts) |       <sup>-66% </sup>`2.27 MB` |       <sup>-41% </sup>`490.34 kB` | <sup>*46x* </sup>`23,456 ms` |
+| [esbuild](/lib/minifiers/esbuild.ts)                                               |       <sup>-65% </sup>`2.31 MB` |       <sup>-41% </sup>`491.09 kB` |   **<sup>🏆 </sup>`509 ms`** |
+| [babel-minify](/lib/minifiers/babel-minify.ts) <sub>_Failed_</sub>                 |                               — |                                 — |                            — |
 <!-- benchmarks:end -->
 
 ---


### PR DESCRIPTION
## Problem
The Commonjs version of Vue was being minified. In case that minifiers assumed it was a global script, it would not minify top-level variables (eg. esbuild).

## Changes
Use UMD version of Vue.js
