### PR TITLE
perf: set swc minifier.compress.passes to 1

### DIFF
--- a/lib/minifiers/swc.ts
+++ b/lib/minifiers/swc.ts
@@ -4,7 +4,7 @@ import { minifier } from '../types';
 export default minifier(async ({ code }) => {
 	const minified = await minify(code, {
 		compress: {
-			// passes: 1,
+			passes: 1,
 		},
 		mangle: true,
 		sourceMap: false,

--- a/lib/minifiers/swc.ts
+++ b/lib/minifiers/swc.ts
@@ -3,7 +3,9 @@ import { minifier } from '../types';
 
 export default minifier(async ({ code }) => {
 	const minified = await minify(code, {
-		compress: true,
+		compress: {
+			// passes: 1,
+		},
 		mangle: true,
 		sourceMap: false,
 	});


### PR DESCRIPTION
I found that setting `compress.passes` from default 3 to 1 increase a little generated file size but reduces a lot time (especially when the input file is large).
Notice that, terser also set `passes` to 1 by default.
![image](https://user-images.githubusercontent.com/17974631/205861834-becd862c-70b6-491e-9d14-8adbcb3d3472.png)
e.g.
## Using default `passes = 3` and `passes = 1`
### Typescript 
![156fa014-0157-4e17-9aeb-745e8ae8ce1b](https://user-images.githubusercontent.com/17974631/205862476-b7f38282-5332-4b5b-962c-ffc541b96ee9.jpeg)
`minifyGzippedSize` from `844.0KB` to `847.6KB`, increase `3.6KB`
`comressTime` from `1234ms` to `790ms`, reducing about 444ms, about 36%
### Antd
`minifyGzippedSize` from `453.4KB` to `457.7`, increase `4.3KB`
`comressTime` from `628ms` to `480ms`, reducing about 148ms, about 23.5%