### PR TITLE
perf(Terser): set minify target to ES2018

### DIFF
--- a/lib/minifiers/terser.ts
+++ b/lib/minifiers/terser.ts
@@ -3,6 +3,7 @@ import { minifier } from '../types';
 
 export default minifier(async ({ code }) => {
 	const minified = await minify(code, {
+		ecma: 2018,
 		sourceMap: false,
 		output: {
 			comments: false,


### PR DESCRIPTION
Helps improve unfair benchmarking by configuring Terser to minify to ES2018 just like esbuild.
Other minifiers (I didn't check) may still be minifying to ES5.

https://github.com/privatenumber/minification-benchmarks/issues/417