### PR TITLE
Document the fact that Closure advanced optimizations are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project benchmarks the following minifiers:
 - [babel-minify](https://github.com/babel/minify/tree/master/packages/babel-minify) <sub>v0.5.2</sub>
 - [bun](https://github.com/oven-sh/bun) <sub>v1.1.29</sub>
 - [esbuild](https://github.com/evanw/esbuild) <sub>v0.24.0</sub>
-- [google-closure-compiler](https://github.com/google/closure-compiler-npm/tree/master/packages/google-closure-compiler) <sub>v20240317.0.0</sub>
+- [google-closure-compiler](https://github.com/google/closure-compiler-npm/tree/master/packages/google-closure-compiler) <sub>v20240317.0.0, advanced optimizations disabled</sub>
 - [tedivm/jshrink](https://github.com/tedious/JShrink) <sub>v1.7.0</sub>
 - [@swc/core](https://github.com/swc-project/swc) <sub>v1.7.28</sub>
 - [@tdewolff/minify](https://github.com/tdewolff/minify#readme) <sub>v2.20.37</sub>
@@ -42,6 +42,10 @@ _Benchmarks last updated on <!-- lastUpdated:start -->Sep 26, 2024<!-- lastUpdat
 - Artifact integrity is verified by a test before and after minification
 - Minifier upgrade PRs are automated via [WhiteSource Renovate](https://www.whitesourcesoftware.com/free-developer-tools/renovate/)
 - Benchmarks are updated on every PR via [GitHub Actions](https://github.com/privatenumber/minification-benchmarks/actions/workflows/benchmark.yml)
+
+## Caveats
+
+- Google Closure Compiler has an ["advanced optimizations" feature](https://developers.google.com/closure/compiler/docs/api-tutorial3), but using those optimizations requires structuring code in a certain way. Our benchmarks focus on popular libraries with the assumption that we cannot alter the code we're minifying. Thus, our Closure Compiler tests don't use advanced optimizations.
 
 ## ⏱ Metrics
 


### PR DESCRIPTION
Hello — this pull request documents the fact that these benchmarks disable Google Closure Compiler's "advanced optimizations." In my opinion this is important context for interpreting the results.

The specific context I intend to communicate in the pull request is:

* These benchmarks run with Closure Compiler's advanced optimizations turned _off_.
* It's not feasible to turn on the advanced optimizations for these benchmarks, because the advanced optimizations require you to structure code in a certain way. These benchmarks run minification on _third-party JS libraries_, with the assumption that the code is "out of our control."

If people are using these benchmarks to decide which minification library to use on their own JS projects, they should be aware of the Closure Compiler advanced optimizations possibility. Otherwise this set of benchmarks is misleading — or, at the very least, paints an incomplete picture.

I have no affiliation with Google or with the Closure Compiler project, aside from having used it for 10+ years now in my own projects. If you take the time to structure your code to take advantage of the "advanced optimizations," it results in significantly better minification than any other library.

Previously: issue #168 brought up the fact that these benchmarks don't use advanced optimizations, and the issue was closed. If the scope of these benchmarks is to remain on third-party JS libraries, I agree it makes sense not to do an advanced optimizations test — because that would require you to tweak those third-party JS libraries. But I _do_ think you should be transparent about this limitation.