### PR TITLE
fix: align ecma target version to es2020 for esbuild, oxc, swc and terser

### DIFF
--- a/packages/minifiers/minifiers/esbuild.ts
+++ b/packages/minifiers/minifiers/esbuild.ts
@@ -6,6 +6,7 @@ export default createMinifier(
 	{
 		default: async ({ code }) => {
 			const minified = await esbuild.transform(code, {
+				target: 'es2020',
 				minify: true,
 				sourcemap: false,
 				legalComments: 'none',

--- a/packages/minifiers/minifiers/oxc-minify.ts
+++ b/packages/minifiers/minifiers/oxc-minify.ts
@@ -5,7 +5,11 @@ export default createMinifier(
 	'oxc-minify',
 	{
 		default: async ({ filePath, code }) => {
-			const minified = await minify(filePath, code);
+			const minified = minify(filePath, code, {
+				compress: {
+					target: 'es2020',
+				},
+			});
 			return minified.code;
 		},
 	},

--- a/packages/minifiers/minifiers/swc.ts
+++ b/packages/minifiers/minifiers/swc.ts
@@ -6,7 +6,9 @@ export default createMinifier(
 	{
 		default: async ({ code }) => {
 			const minified = await minify(code, {
-				compress: true,
+				compress: {
+					ecma: 'es2020',
+				},
 				mangle: true,
 				sourceMap: false,
 			});

--- a/packages/minifiers/minifiers/terser.ts
+++ b/packages/minifiers/minifiers/terser.ts
@@ -6,7 +6,7 @@ export default createMinifier(
 	{
 		default: async ({ code }) => {
 			const minified = await minify(code, {
-				ecma: 2018,
+				ecma: 2020,
 				sourceMap: false,
 				output: {
 					comments: false,
@@ -17,7 +17,7 @@ export default createMinifier(
 		},
 		'no compress': async ({ code }) => {
 			const minified = await minify(code, {
-				ecma: 2018,
+				ecma: 2020,
 				sourceMap: false,
 				output: {
 					comments: false,


### PR DESCRIPTION
The highest ecma version for terser is es2020, so align all to es2020.