### PR TITLE
Fix configuration ambiguity in TypeScript test caused by evaluating code in a different environment than it was transpiled for

### DIFF
--- a/packages/artifacts/artifacts/typescript/test.ts
+++ b/packages/artifacts/artifacts/typescript/test.ts
@@ -7,6 +7,12 @@ export default defineTest<typeof import('typescript')>({
 		const result = ts.transpileModule(source, {
 			compilerOptions: {
 				target: ts.ScriptTarget.ES3,
+
+				// In browsers, TypeScript defaults to \r\n. We are running
+				// TypeScript in Node.js, but we built TypeScript for the
+				// browser so let's explicitly choose the desired newline
+				// character.
+				newLine: ts.NewLineKind.LineFeed,
 			},
 		});
 


### PR DESCRIPTION
In browsers, TypeScript defaults the newline character it outputs to `\r\n`, but the test verifying TypeScript's output is running in Node.js. The runtime the code is transpiled for is not specified, but since this is a minification benchmark, it's reasonable to assume it's meant for browsers.

When building TypeScript for the browser, TypeScript chooses `\r\n` as the default newline character instead of the OS-specific end of line character, as shown below:
```ts
var carriageReturnLineFeed = "\r\n";
var lineFeed = "\n";
function getNewLineCharacter(options, getNewLine) {
    switch (options.newLine) {
        case 0 /* NewLineKind.CarriageReturnLineFeed */:
            return carriageReturnLineFeed;
        case 1 /* NewLineKind.LineFeed */:
            return lineFeed;
    }
    return getNewLine ? getNewLine() : ts.sys ? ts.sys.newLine : carriageReturnLineFeed;
}
```

Note that in a browser, `ts.sys` is undefined, so it falls back to `carriageReturnLineFeed`.

When run inside Node.js, TypeScript chooses the OS-specific line ending:
```js
var nodeSystem = {
     args: process.argv.slice(2),
     newLine: _os.EOL,
```

This makes the newline character to use ambiguous. 

So instead, we can explicitly pass the newline character to use.