### PR TITLE
feat: add manual benchmark refresh workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,19 @@ on:
   pull_request:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      minifier:
+        description: Minifier name or regular expression (empty refreshes all)
+        required: false
+        type: string
+      artifact:
+        description: Artifact name or regular expression (empty refreshes all)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   build:
@@ -14,36 +27,56 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'master' || github.head_ref }}
           repository: ${{ github.repository }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           run_install: true
 
       # For jshrink
       - name: Setup Composer
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           working_dir: packages/minifiers
 
       # For Google Closure Compiler
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Benchmark
+        if: github.event_name == 'pull_request'
         run: pnpm bench-all
+
+      - name: Force benchmark refresh
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          ARTIFACT_FILTER: ${{ inputs.artifact }}
+          MINIFIER_FILTER: ${{ inputs.minifier }}
+        run: |
+          set -euo pipefail
+
+          arguments=(--force)
+          if [[ -n "$ARTIFACT_FILTER" ]]; then
+            arguments+=(--artifact "$ARTIFACT_FILTER")
+          fi
+          if [[ -n "$MINIFIER_FILTER" ]]; then
+            arguments+=(--minifier "$MINIFIER_FILTER")
+          fi
+
+          pnpm bench-all "${arguments[@]}"
 
       - name: Update README
         run: pnpm update-readme
@@ -51,10 +84,56 @@ jobs:
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
 
       - name: Commit README.md
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Ignored by Renovate
+          gh auth setup-git
           git config user.name GitHub Actions
           git config user.email github-actions@github.com
           git add README.md packages/data/data/data.json
           git diff-index --quiet HEAD || git commit -nm "chore: updated benchmarks"
           git push
+
+      - name: Open pull request
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          ARTIFACT_FILTER: ${{ inputs.artifact }}
+          GH_TOKEN: ${{ github.token }}
+          MINIFIER_FILTER: ${{ inputs.minifier }}
+        run: |
+          set -euo pipefail
+
+          git add README.md packages/data/data/data.json
+          if git diff --cached --quiet; then
+            echo "No benchmark changes to submit"
+            exit 0
+          fi
+
+          git config user.name GitHub Actions
+          git config user.email github-actions@github.com
+          gh auth setup-git
+
+          branch="refresh-benchmarks-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git switch -c "$branch"
+          git commit -nm "chore: refresh benchmark results"
+          git push --set-upstream origin "$branch"
+
+          body="Force-refreshes benchmark results from the manual Benchmark workflow."
+          if [[ -n "$MINIFIER_FILTER" ]]; then
+            body+=$'\n\nMinifier filter: `'
+            body+="$MINIFIER_FILTER"
+            body+='`'
+          fi
+          if [[ -n "$ARTIFACT_FILTER" ]]; then
+            body+=$'\n\nArtifact filter: `'
+            body+="$ARTIFACT_FILTER"
+            body+='`'
+          fi
+
+          gh pr create \
+            --base master \
+            --head "$branch" \
+            --title "chore: refresh benchmark results" \
+            --body "$body"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project benchmarks the following minifiers:
 | [tedivm/jshrink](https://github.com/tedious/JShrink) | 1.8.1 |  |
 <!-- minifiers:end -->
 
-_Benchmarks last updated on <!-- lastUpdated:start -->Jul 24, 2026<!-- lastUpdated:end -->._
+_Benchmarks last updated on <!-- lastUpdated:start -->Jul 25, 2026<!-- lastUpdated:end -->._
 
 <br>
 
@@ -424,37 +424,32 @@ How long minification took (average of 5 runs). Each time is annotated with a mu
 > 🤖 This analysis is AI generated. See below for the system prompt.
 
 <!-- aiAnalysis:start -->
-# The Minification Grand Prix: 12 Rounds of Byte-Shaving Mayhem
+# The Minification Grand Prix: 12 Rounds of Byte-Shaving Brutality
 
-Twelve npm packages. Eleven contenders. One goal: crush code down to its smallest, fastest-loading form without breaking a sweat—or the syntax. From the featherweight "react" to the typescript behemoth clocking in at nearly 2 megabytes, this race had everything. Early sprinters flamed out, a couple of veterans refused to compromise on size no matter the time cost, and one newcomer quietly lapped the field as the packages got heavier. Let's break down who deserves the podium.
+Twelve packages. Eleven contenders. One brutal truth: size and speed rarely hold hands. From the featherweight "react" to the typescript colossus lumbering in at nearly two megabytes, this race tested every minifier's nerve. Some sprinted. Some sculpted. Two didn't even make it to the podium in one piece. Let's break down the carnage.
 
 ### Best minifier
 
-**@swc/core** takes the crown, and it wasn't close once you factor in the whole picture. Look at the pattern: round after round, it either wins outright on compression or sits within a rounding error of the winner—while doing it in milliseconds, not seconds. On "jquery," "vue," "three," and "echarts," @swc/core delivered the single smallest gzip output *and* did it fast enough to be labeled "most balanced" nearly every time. That's not a fluke, that's a system.
-
-Compare that to uglify-js, which absolutely wins on raw compression in several rounds—"moment," "lodash," "d3," "victory"—but at a brutal cost. On "victory" alone, uglify-js took 5.7 *seconds* to shave a bit more fat than the field. On "d3," 3.2 seconds for a 33% cut that oxc-minify essentially matched in 37 milliseconds. That's an 88x time penalty for marginal gains. In a CI pipeline running thousands of builds a day, that's not dedication—that's a bottleneck.
-
-@swc/core proved you don't have to choose. It's consistently top-tier on size and finishes its work before slower tools have finished loading their config files.
+**@swc/core** takes the crown, and honestly, it wasn't close once you factor in the whole picture. It won or nearly-won "Best gzip compression" on six of twelve rounds — jquery, vue, three, victory, echarts — while consistently finishing in double-digit or low-triple-digit milliseconds. Compare that to uglify-js, which *does* squeeze out smaller bytes in a few rounds (react, moment, lodash, d3, victory) but pays for it in blood: 5,712 ms on victory and 3,272 ms on d3, while swc handles the same packages in 244 ms and 129 ms respectively. That's not a rounding error — that's uglify-js taking a leisurely coffee break while swc's already lapped the track twenty times. When the source code gets genuinely massive (echarts, antd, typescript), swc and oxc-minify trade blows for the top compression spot while staying blisteringly fast. Uglify-js, meanwhile, seems to slow down almost linearly with size, making it a liability for anything beyond toy bundles. Swc gives you 90-95% of the best possible compression at a fraction of the time cost, across every single test. That's not just a good minifier — that's a dependable one.
 
 ### Honorable mentions
 
-**oxc-minify** is the breakout star of the back half of this race. As packages ballooned into the hundreds of kilobytes and beyond, oxc-minify started winning outright—"terser," "antd," "typescript"—all while running at speeds that make uglify-js look like it's minifying by hand. On "typescript," it shaved 55% off nearly 2MB in just 531ms. That's the kind of scaling that matters when your bundle isn't a toy example.
+**oxc-minify** deserves a standing ovation. It's the closest thing to a perpetual runner-up to swc, but on typescript, antd, and terser-the-package, it actually took gold for compression while finishing in under 550 ms even on multi-megabyte inputs. If swc ever stumbles, oxc is right there to catch the baton — and it's often faster.
 
-**@tdewolff/minify** is the speed demon's speed demon. It topped the "fastest" category in almost every single round, often finishing in single-digit milliseconds even on large payloads, and its compression, while rarely table-topping, was never embarrassing—usually within 1-3% of the leaders. If your CI cares about wall-clock time above all, this is your dark horse.
+**@tdewolff/minify** is the speed demon's speed demon. It topped "Fastest" in nearly every single round, often finishing in single-digit to low double-digit milliseconds, and its compression, while rarely best-in-class, never falls off a cliff either. This is your CI pipeline's best friend when you need answers *now* and can tolerate a few extra kilobytes.
 
-**@cminify/cminify-linux-x64** deserves a nod purely for consistency of speed on huge files—routinely the fastest or near-fastest on anything over 100KB—even though its compression ratios lagged well behind the leaders (that "d3" result, 21% shaved versus uglify's 33%, shows the gap widens on gnarlier code).
+**@cminify/cminify-linux-x64** is the sprinter of the group on huge files — fastest on every round from d3 onward — but it consistently leaves the most bytes on the table (e.g., only 21-45% shaved when others hit 50%+). Great for a quick pass, not for your production bundle's final form.
 
-**terser** held its own in the early lightweight rounds as a dependable, slightly-slower-but-still-respectable middle-of-the-pack performer—no disasters, no fireworks, just steady work.
+**uglify-js** remains a compression savant on small-to-mid packages, but its runtime scales terribly. Use it if you're optimizing a small library once and don't mind waiting; skip it for anything at scale or in a fast feedback loop.
 
 ### Eliminated
 
-**babel-minify** — Crashed out at the very first hurdle on "react," tripped up by a stale internal browser-data dependency throwing a JSON parsing error. Never got off the starting line.
-
-**tedivm/jshrink** — Made it through five rounds respectably, then choked on "d3" with an unclosed regex pattern exception. A hard crash on real-world code is a hard no for production use, regardless of how it performed before that.
+- **babel-minify** — Crashed on the very first round ("react") due to an internal dependency data-freshness error unrelated to the actual minification logic. Never got off the starting line.
+- **tedivm/jshrink** — Choked on "d3" with an unclosed regex pattern exception, a sign its parser couldn't handle real-world modern JS. Disqualified for breaking mid-race.
 
 ### Closing remarks
 
-What a card. The story of this race is really the story of a shifting frontier: uglify-js reminding us that raw compression obsession still has fans willing to pay in seconds, while @swc/core and oxc-minify prove that modern tooling can deliver both speed and squeeze without forcing you to pick a side. @tdewolff/minify and @cminify show there's real appetite for tools that prioritize throughput above all else. Numbers don't lie, but they also don't tell you everything—installation footprint, plugin ecosystems, and how a tool handles your particular edge-case syntax still matter enormously. Take these results as a strong compass, not gospel, and pick the minifier that matches the shape of your actual pipeline, not just the podium finish.
+The final standings tell a clear story: raw compression ratio and speed are both winnable games, but only a few tools play both well. @swc/core is this year's most complete athlete, oxc-minify is the electrifying challenger nipping at its heels, and tdewolff/minify is the one you call when milliseconds are the only currency that matters. Uglify-js proves that old-school muscle still squeezes bytes better than most — just don't ask it to hurry. As always, benchmarks are only half the story: installation footprint, plugin ecosystems, and how well a tool fits your build pipeline matter just as much as the numbers here. Pick your fighter based on what your pipeline actually needs — and maybe keep two in the toolbox, just in case.
 <!-- aiAnalysis:end -->
 
 <details>
@@ -462,7 +457,7 @@ What a card. The story of this race is really the story of a shifting frontier: 
 <br>
 
 <pre><code><!-- aiSystemPrompt:start -->
-Today&#39;s date is 2026-07-24
+Today&#39;s date is 2026-07-25
 
 You are a JavaScript minification benchmark analyst with a flair for storytelling.
 

--- a/README.md
+++ b/README.md
@@ -424,32 +424,32 @@ How long minification took (average of 5 runs). Each time is annotated with a mu
 > 🤖 This analysis is AI generated. See below for the system prompt.
 
 <!-- aiAnalysis:start -->
-# The Minification Grand Prix: 12 Rounds of Byte-Shaving Brutality
-
-Twelve packages. Eleven contenders. One brutal truth: size and speed rarely hold hands. From the featherweight "react" to the typescript colossus lumbering in at nearly two megabytes, this race tested every minifier's nerve. Some sprinted. Some sculpted. Two didn't even make it to the podium in one piece. Let's break down the carnage.
+```md
+Ladies and gentlemen, start your compressors! Twelve rounds, eleven contenders, and file sizes ranging from a dainty 19 KB React bundle to a genuinely unhinged 1.88 MB TypeScript compiler dump. This wasn't just a benchmark — it was a gauntlet. Some tools sprinted, some tools crawled with a trophy in hand, and two contenders spectacularly imploded before they even reached the finish line. Let's get into it.
 
 ### Best minifier
-
-**@swc/core** takes the crown, and honestly, it wasn't close once you factor in the whole picture. It won or nearly-won "Best gzip compression" on six of twelve rounds — jquery, vue, three, victory, echarts — while consistently finishing in double-digit or low-triple-digit milliseconds. Compare that to uglify-js, which *does* squeeze out smaller bytes in a few rounds (react, moment, lodash, d3, victory) but pays for it in blood: 5,712 ms on victory and 3,272 ms on d3, while swc handles the same packages in 244 ms and 129 ms respectively. That's not a rounding error — that's uglify-js taking a leisurely coffee break while swc's already lapped the track twenty times. When the source code gets genuinely massive (echarts, antd, typescript), swc and oxc-minify trade blows for the top compression spot while staying blisteringly fast. Uglify-js, meanwhile, seems to slow down almost linearly with size, making it a liability for anything beyond toy bundles. Swc gives you 90-95% of the best possible compression at a fraction of the time cost, across every single test. That's not just a good minifier — that's a dependable one.
+The crown goes to **oxc-minify**, and here's why the decision — while close — ultimately wasn't a coin flip. Early on, oxc looked like the "fast but not the smallest" kid in class, consistently clocking single-digit-to-low-double-digit millisecond times while conceding a sliver of compression to the heavyweights. But watch what happens as the files get monstrous. On the 825 KB antd bundle, oxc wins outright on size AND does it in 255 ms — nearly three times faster than its closest size rival. On the colossal 1.88 MB TypeScript bundle, oxc doesn't just win, it wins by shaving 55% off the payload in 531 milliseconds, a time that would barely register a blip in most CI pipelines. That's the real story here: oxc doesn't just compete at scale, it dominates at scale, and scale is where minifiers earn their keep. Consistent top-three finishes across all twelve rounds, plus podium-topping speed almost everywhere, make it the most complete athlete on the track.
 
 ### Honorable mentions
+**@swc/core** deserves a standing ovation. It topped the "best gzip" leaderboard outright on jquery, vue, three, and echarts, and was tagged "most balanced" in nearly every single round. It's the decathlete of this competition — never flashy in just one event, but relentlessly excellent across all of them. If oxc is the scale champion, swc is the Swiss Army knife.
 
-**oxc-minify** deserves a standing ovation. It's the closest thing to a perpetual runner-up to swc, but on typescript, antd, and terser-the-package, it actually took gold for compression while finishing in under 550 ms even on multi-megabyte inputs. If swc ever stumbles, oxc is right there to catch the baton — and it's often faster.
+**uglify-js** is the old-school power-lifter. It posted the best raw compression on react, moment, lodash, d3, and victory — genuinely impressive numbers, shaving 74% off lodash at one point. But the cost is brutal: 5,712 milliseconds to squeeze victory down, compared to swc's near-identical result in 244 ms. That's more than twenty times slower for a rounding-error difference in size. Uglify-js is the guy who wins the bench-press competition but takes an hour between reps — brilliant output, questionable for anyone on a deadline.
 
-**@tdewolff/minify** is the speed demon's speed demon. It topped "Fastest" in nearly every single round, often finishing in single-digit to low double-digit milliseconds, and its compression, while rarely best-in-class, never falls off a cliff either. This is your CI pipeline's best friend when you need answers *now* and can tolerate a few extra kilobytes.
+**@cminify/cminify-linux-x64** wins the "fastest raw speed" trophy in almost every single round, often finishing in the 12-70 ms range regardless of file size. The catch: it consistently leaves the most bytes on the table, sometimes 10-15 percentage points behind the compression leaders. Great for a quick-and-dirty pass, not the tool you call when every kilobyte matters.
 
-**@cminify/cminify-linux-x64** is the sprinter of the group on huge files — fastest on every round from d3 onward — but it consistently leaves the most bytes on the table (e.g., only 21-45% shaved when others hit 50%+). Great for a quick pass, not for your production bundle's final form.
+**@tdewolff/minify** quietly picked up fastest-tool honors on several mid-size rounds and stayed competitive on compression throughout — a dependable, understated performer.
 
-**uglify-js** remains a compression savant on small-to-mid packages, but its runtime scales terribly. Use it if you're optimizing a small library once and don't mind waiting; skip it for anything at scale or in a fast feedback loop.
+**terser** flashed some early brilliance (honorable mentions on react and moment) but faded from the spotlight as file sizes ballooned — strong at the sprint, less visible at the marathon.
+
+Special mention to the no-shows: **google-closure-compiler** and **bun** never once cracked a podium category across all twelve rounds. Not disqualified, not broken — just invisible in a field this competitive. Sometimes silence speaks volumes.
 
 ### Eliminated
-
-- **babel-minify** — Crashed on the very first round ("react") due to an internal dependency data-freshness error unrelated to the actual minification logic. Never got off the starting line.
-- **tedivm/jshrink** — Choked on "d3" with an unclosed regex pattern exception, a sign its parser couldn't handle real-world modern JS. Disqualified for breaking mid-race.
+- **babel-minify**: Face-planted immediately on the very first round (react), tripped up by a stale dependency data error before minification even got going. Didn't even get a chance to compete.
+- **tedivm/jshrink**: Choked on the d3 package with an unclosed regex pattern exception, crashing mid-minification. A hard stop that disqualifies it from anything involving gnarlier real-world code.
 
 ### Closing remarks
-
-The final standings tell a clear story: raw compression ratio and speed are both winnable games, but only a few tools play both well. @swc/core is this year's most complete athlete, oxc-minify is the electrifying challenger nipping at its heels, and tdewolff/minify is the one you call when milliseconds are the only currency that matters. Uglify-js proves that old-school muscle still squeezes bytes better than most — just don't ask it to hurry. As always, benchmarks are only half the story: installation footprint, plugin ecosystems, and how well a tool fits your build pipeline matter just as much as the numbers here. Pick your fighter based on what your pipeline actually needs — and maybe keep two in the toolbox, just in case.
+What a field. Some tools chase the smallest possible byte count and are willing to burn seconds doing it. Others treat speed as sacred and give up a little compression for it. oxc-minify and swc proved you can have both — consistency, size, and speed — without major compromises, especially once file sizes get serious. But raw numbers are only half the story: install footprint, API ergonomics, and community support all matter once these tools leave the benchmark and enter your actual build pipeline. Take these results as your starting line, not your finish line — and pick the minifier that fits the race you're actually running.
+```
 <!-- aiAnalysis:end -->
 
 <details>


### PR DESCRIPTION
## Problem

Cached benchmark results can outlive fixes to the benchmark runner, as happened when babel-minify's stale parser failures remained in `data.json` after the parser was corrected. The existing manual workflow had no way to select and force affected results, and it pushed generated changes directly instead of providing a review boundary.

## Changes

Manual Benchmark runs now accept optional minifier and artifact filters, force matching benchmarks, regenerate the README, and open a dedicated pull request against `master`. Empty filters refresh the full suite, and runs with no generated changes exit without opening a PR.

Normal pull-request benchmark behavior remains unchanged. The workflow also upgrades obsolete action runtimes, pins every action to an immutable commit, declares the required token permissions, and configures git authentication only in steps that push.
