### PR TITLE
ci: preserve benchmarks before AI analysis

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Commit README.md
         run: |
           # Ignored by Renovate
-          git config user.name GitHub Actions
-          git config user.email github-actions@github.com
+          git config user.name "minification-benchmarks automation"
+          git config user.email actions@users.noreply.github.com
           git add README.md packages/data/data/data.json
-          git diff-index --quiet HEAD || git commit -nm "chore: updated benchmarks"
+          git diff-index --quiet HEAD || git commit -nm "chore: update benchmark results"
           git push

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,19 +42,32 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Configure Git
+        run: |
+          git config user.name "minification-benchmarks automation"
+          git config user.email actions@users.noreply.github.com
+
       - name: Benchmark
         run: pnpm bench-all
+
+      - name: Commit benchmark results
+        run: |
+          # Ignored by Renovate
+          git add packages/data/data/data.json
+          if ! git diff --cached --quiet; then
+            git commit -nm "chore: update benchmark results"
+            git push
+          fi
 
       - name: Update README
         run: pnpm update-readme
         env:
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
 
-      - name: Commit README.md
+      - name: Commit benchmark report
         run: |
-          # Ignored by Renovate
-          git config user.name "minification-benchmarks automation"
-          git config user.email actions@users.noreply.github.com
-          git add README.md packages/data/data/data.json
-          git diff-index --quiet HEAD || git commit -nm "chore: update benchmark results"
-          git push
+          git add README.md
+          if ! git diff --cached --quiet; then
+            git commit -nm "docs: update benchmark report"
+            git push
+          fi


### PR DESCRIPTION
## Problem

The benchmark workflow treated benchmark execution and AI-generated commentary as one operation. It committed both only after the AI request succeeded. If AI Gateway failed after the benchmarks finished, the runner discarded the new results and the next attempt had to run every benchmark again.

The generated commit also used the ambiguous `GitHub Actions <github-actions@github.com>` identity. Squash merges therefore listed an unexplained generic GitHub co-author instead of identifying the repository automation.

## Changes

Benchmark results are now committed and pushed immediately after measurement. The workflow generates and commits the README report afterward, so an AI failure remains visible in CI but cannot discard completed benchmark work. On retry, `bench-all` reads the committed matching results and skips that work before retrying the report.

Both generated commits use the explicit `minification-benchmarks automation <actions@users.noreply.github.com>` identity. Their subjects distinguish the stored measurements (`chore: update benchmark results`) from the rendered report (`docs: update benchmark report`).
