### PR TITLE
ci: cache benchmark results across Renovate rebases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,12 @@ on:
     branches: [master]
   workflow_dispatch:
 
+env:
+  # Part of the benchmark checkpoint cache key below. Bump when benchmark
+  # results are affected by something the checkpoint inputs don't capture,
+  # such as a runner image change or benchmark settings configured here.
+  BENCHMARK_CHECKPOINT_VERSION: v1
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,18 +20,18 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.repository }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           run_install: true
 
@@ -37,7 +43,7 @@ jobs:
 
       # For Google Closure Compiler
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "21"
@@ -50,8 +56,64 @@ jobs:
           # as automation
           git config user.email github-actions@github.com
 
+      # Renovate recreates its branches from the base branch, discarding the
+      # generated results commit. Cache data.json so the benchmark only re-runs
+      # measurements whose inputs changed. The key fingerprints the benchmark
+      # inputs and the checked-out results, so a restored checkpoint can never
+      # overwrite newer committed results. Report generation is excluded:
+      # README-only changes reuse the cached results.
+      - name: Compute benchmark checkpoint key
+        id: checkpoint-key
+        run: |
+          files_hash=$(
+            git ls-files -z -- \
+              pnpm-lock.yaml \
+              pnpm-workspace.yaml \
+              package.json \
+              .nvmrc \
+              packages/bench \
+              packages/minifiers \
+              packages/artifacts \
+              packages/utils \
+              packages/data \
+              ':(exclude)packages/data/update-readme' \
+              | xargs -0 sha256sum \
+              | sha256sum \
+              | cut -d' ' -f1
+          )
+          # Only capture major/minor runtime versions so runner image updates
+          # don't invalidate otherwise-identical checkpoints
+          runtime_hash=$(
+            printf '%s\n' \
+              "$RUNNER_OS" \
+              "$RUNNER_ARCH" \
+              "$(. /etc/os-release && echo "$VERSION_ID")" \
+              "$(node -p 'process.versions.node.split(".").slice(0, 2).join(".")')" \
+              "$(php -r 'echo PHP_MAJOR_VERSION, ".", PHP_MINOR_VERSION;')" \
+              "$(java -version 2>&1 | head -n1 | sed -E 's/.*"([0-9]+).*/\1/')" \
+              | sha256sum \
+              | cut -d' ' -f1
+          )
+          echo "key=benchmark-checkpoint-${BENCHMARK_CHECKPOINT_VERSION}-${files_hash}-${runtime_hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore benchmark checkpoint
+        id: checkpoint
+        uses: actions/cache/restore@v6
+        with:
+          path: packages/data/data/data.json
+          key: ${{ steps.checkpoint-key.outputs.key }}
+
       - name: Benchmark
         run: pnpm bench-all
+
+      # Save before committing so the checkpoint survives failures in the
+      # commit or report steps
+      - name: Save benchmark checkpoint
+        if: steps.checkpoint.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: packages/data/data/data.json
+          key: ${{ steps.checkpoint-key.outputs.key }}
 
       - name: Commit benchmark results
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,12 +5,6 @@ on:
     branches: [master]
   workflow_dispatch:
 
-env:
-  # Part of the benchmark checkpoint cache key below. Bump when benchmark
-  # results are affected by something the checkpoint inputs don't capture,
-  # such as a runner image change or benchmark settings configured here.
-  BENCHMARK_CHECKPOINT_VERSION: v1
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -58,62 +52,25 @@ jobs:
 
       # Renovate recreates its branches from the base branch, discarding the
       # generated results commit. Cache data.json so the benchmark only re-runs
-      # measurements whose inputs changed. The key fingerprints the benchmark
-      # inputs and the checked-out results, so a restored checkpoint can never
-      # overwrite newer committed results. Report generation is excluded:
-      # README-only changes reuse the cached results.
-      - name: Compute benchmark checkpoint key
-        id: checkpoint-key
-        run: |
-          files_hash=$(
-            git ls-files -z -- \
-              pnpm-lock.yaml \
-              pnpm-workspace.yaml \
-              package.json \
-              .nvmrc \
-              packages/bench \
-              packages/minifiers \
-              packages/artifacts \
-              packages/utils \
-              packages/data \
-              ':(exclude)packages/data/update-readme' \
-              | xargs -0 sha256sum \
-              | sha256sum \
-              | cut -d' ' -f1
-          )
-          # Only capture major/minor runtime versions so runner image updates
-          # don't invalidate otherwise-identical checkpoints
-          runtime_hash=$(
-            printf '%s\n' \
-              "$RUNNER_OS" \
-              "$RUNNER_ARCH" \
-              "$(. /etc/os-release && echo "$VERSION_ID")" \
-              "$(node -p 'process.versions.node.split(".").slice(0, 2).join(".")')" \
-              "$(php -r 'echo PHP_MAJOR_VERSION, ".", PHP_MINOR_VERSION;')" \
-              "$(java -version 2>&1 | head -n1 | sed -E 's/.*"([0-9]+).*/\1/')" \
-              | sha256sum \
-              | cut -d' ' -f1
-          )
-          echo "key=benchmark-checkpoint-${BENCHMARK_CHECKPOINT_VERSION}-${files_hash}-${runtime_hash}" >> "$GITHUB_OUTPUT"
-
-      - name: Restore benchmark checkpoint
-        id: checkpoint
+      # measurements whose inputs changed.
+      - name: Restore benchmark results
+        id: benchmark-cache
         uses: actions/cache/restore@v6
         with:
           path: packages/data/data/data.json
-          key: ${{ steps.checkpoint-key.outputs.key }}
+          key: benchmark-${{ hashFiles('pnpm-lock.yaml', 'packages/minifiers/composer.lock', 'packages/data/data/data.json') }}
 
       - name: Benchmark
         run: pnpm bench-all
 
-      # Save before committing so the checkpoint survives failures in the
+      # Save before committing so the results survive failures in the
       # commit or report steps
-      - name: Save benchmark checkpoint
-        if: steps.checkpoint.outputs.cache-hit != 'true'
+      - name: Save benchmark results
+        if: steps.benchmark-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: packages/data/data/data.json
-          key: ${{ steps.checkpoint-key.outputs.key }}
+          key: ${{ steps.benchmark-cache.outputs.cache-primary-key }}
 
       - name: Commit benchmark results
         run: |

--- a/README.md
+++ b/README.md
@@ -424,36 +424,28 @@ How long minification took (average of 5 runs). Each time is annotated with a mu
 > 🤖 This analysis is AI generated. See below for the system prompt.
 
 <!-- aiAnalysis:start -->
-Three... two... one... compress! Welcome back to the Minification Grand Prix, where eleven contenders line up, kilobytes tremble, and milliseconds separate legends from footnotes. This year's grid features grizzled veterans, Rust-powered newcomers, and one PHP wildcard that—well, we'll get to that. Twelve rounds, from the sprint-sized "react" to the marathon monolith "typescript" at 1.88 MB gzipped. Laces tied. Engines warmed. Let's shave some bytes!
+Three... two... one... compress! Welcome to the Minification Grand Prix, where every byte counts, every millisecond stings, and eleven brave tools lined up to shave a mountain of JavaScript down to a pebble. From dainty little React to the absolute colossus that is TypeScript at nearly two megabytes gzipped, this year's circuit was brutal—and the leaderboard shook more than once.
 
 ### Best minifier
-
-The crown goes to **oxc-minify**, and it's the kind of victory that makes statisticians nervous.
-
-Here's the story of the race. On raw compression, @swc/core actually grabbed more "best size" banners—it was often within half a percent of the absolute floor while still clocking absurd times like 46 ms on "jquery." But oxc-minify refused to lose that coin flip. It ran *three to four times faster than swc* nearly every lap, and its compression penalty was typically a rounding error—think 43.25 KB versus 42.71 KB on "vue," a gap your users will never feel over a wire.
-
-Then came the heavyweight rounds, and the race broke open. On "antd" and the towering "typescript" package, oxc-minify posted the smallest result *and* the best meaningful speed—852.78 KB from 1.88 MB in 531 ms. When the source gets big and mean, oxc didn't just keep pace; it led from the front. A tool that sits within a whisper of the compression champions while being dramatically quicker? In a world of CI pipelines and per-deploy budgets, that's your overall winner. It wasn't a landslide—but it was decisive.
+The crown goes to **oxc-minify**, and honestly, it didn't just win—it rewrote what "young contender" means. On the small classics it stayed glued to the leaders, but where the race was truly decided—on the big, scary artifacts—it pulled away. On terser itself it took the size win outright. On antd and TypeScript, it delivered the smallest output of anyone, *and* did it in a fraction of the time its rivals needed. Chewing through 1.88 MB of gzipped TypeScript in half a second while producing the tightest result in the field? That's not a trade-off, that's a flex. @swc/core pushed it hard all season and stole several rounds, but when the heaviest weights came out, oxc had both the smallest suitcase and the fastest hands. Verdict: undefeated where it matters most.
 
 ### Honorable mentions
+**@swc/core** was the metronome of this Grand Prix—rarely the flashiest, almost always on the podium. It took jquery, vue, three, and echarts on raw compression, and stayed within breathing distance of oxc everywhere else. If you want near-best size without babysitting slow builds, this is your workhorse.
 
-**@swc/core** is the heartbreak story of the season—the perennial silver medalist. It claimed the best-size crown in "jquery," "vue," "three," and "echarts," and never finished far off the pace anywhere. If you want maximum squeeze and can spare the extra milliseconds, this is a magnificent pick.
+**uglify-js** deserves a standing ovation and a nap. It claimed the size crown on react, moment, lodash, and the monstrous victory—proving the old guard can still squeeze with the best of them. The catch? Victory took it nearly six seconds. Beautiful compression, glacial pace. A purist's champion.
 
-**uglify-js** is the old master with creaking knees. It authored the most beautiful compressions in the small and medium rounds—8.18 KB on "react," a gorgeous 24.69 KB on "lodash." But 5.7 seconds on "victory" and 3.2 seconds on "d3" in a field where oxc does the same job in 72 ms? Craftsmanship this slow is a luxury, not a strategy.
+**@tdewolff/minify** was the pocket rocket of the early laps—blistering 7-millisecond runs on moment and respectable size throughout, even on echarts. Never quite the smallest, never off the pace.
 
-**@tdewolff/minify** deserves applause as the pocket rocket of the mid-field—7 ms on "moment," 12 ms on "jquery," and respectable sizes to boot. It drifted back on the giants, but for small-to-medium payloads it's a genuinely compelling speed merchant.
+And a tip of the hat to **@cminify**, the speed specialist: fastest in nearly every heavyweight round, but consistently giving up 10–15% more bytes. That's a lot of extra payload to pay for speed—and when oxc and swc are this fast anyway, it's a hard bill to justify.
 
-**@cminify/cminify-linux-x64** won every sprint it entered but paid dearly at the toll booth—on "typescript" it produced 1.13 MB where oxc managed 852 KB. Fastest lap, worst fuel economy. A niche tool, not a champion.
-
-**esbuild** stayed quietly respectable, and **terser** and **bun** kept the veterans honest without stealing a podium.
+**terser** and **esbuild** showed flashes—terser's early-round numbers were solid, esbuild stayed respectable on lodash—but neither could sustain a challenge across the full season.
 
 ### Eliminated
-
-- **babel-minify** — never left the garage. Its "react" run died before minification even began, tripping over a stale `baseline-browser-mapping` warning it apparently couldn't look past. DNF.
-- **tedivm/jshrink** — ran bravely until "d3," then collapsed mid-stride with an "Unclosed regex pattern" runtime exception. When your minifier crashes on the sixth-largest file, you're out of the race.
+- **babel-minify**: Collapsed before the starting gun on react, tripping over its own baseline-browser-mapping dependency warning. A DNS-style failure at the gate—no times recorded.
+- **tedivm/jshrink**: Ran valiantly through the early rounds, then hit an unclosed regex on d3 and bowed out with a PHP RuntimeException. When a minifier breaks the input it's handed, the bench is the only safe place.
 
 ### Closing remarks
-
-What a day of racing. The Rust generation has officially taken the podium—oxc-minify and @swc/core now trade blows at speeds that make a decade-old toolchain look like dial-up—while uglify-js reminds us that old-fashioned patience still buys the occasional masterpiece. One caution before you sprint to install: these benchmarks measure size and speed, nothing more. Real-world choice also hinges on correctness, API ergonomics, install footprint, and community support—none of which fit on a stopwatch. So take the data, test the finalists against your own code, and pick the one that fits your pipeline. Until next time: keep it small, keep it fast, and may your gzip ratios ever shrink!
+What a race. The new generation—oxc and swc—has officially closed the gap with the veterans, and then some: today they out-compress *and* out-run them. Meanwhile, uglify-js reminds us that pure size obsession still has a home, if you can stomach the wait. A friendly reminder before you sprint to the terminal: benchmarks measure speed and bytes, not developer joy—install size, API ergonomics, and ecosystem support all live outside this scoreboard. And as always, minifiers can break things, so keep those tests green. Pick the tool that fits your pipeline, your patience, and your users' download budgets—and may your bundles forever shrink. See you at the next Grand Prix!
 <!-- aiAnalysis:end -->
 
 <details>

--- a/README.md
+++ b/README.md
@@ -424,23 +424,36 @@ How long minification took (average of 5 runs). Each time is annotated with a mu
 > 🤖 This analysis is AI generated. See below for the system prompt.
 
 <!-- aiAnalysis:start -->
-Three... two... one... compress! Welcome back to the Minification Grand Prix, where kilobytes are currency, milliseconds are pride, and eleven contenders just spent the afternoon feeding whole frameworks into the woodchipper. We went from a svelte little React all the way up to the mountain that is TypeScript — 1.88 megabytes gzipped of pure JavaScript muscle. Some runners cruised. Some runners collapsed. Two didn't even make it out of the parking lot. Let's talk about the ones who did.
+Three... two... one... compress! Welcome back to the Minification Grand Prix, where eleven contenders line up, kilobytes tremble, and milliseconds separate legends from footnotes. This year's grid features grizzled veterans, Rust-powered newcomers, and one PHP wildcard that—well, we'll get to that. Twelve rounds, from the sprint-sized "react" to the marathon monolith "typescript" at 1.88 MB gzipped. Laces tied. Engines warmed. Let's shave some bytes!
 
 ### Best minifier
 
-Ladies and gentlemen, your champion: **oxc-minify**. And what a campaign it was. This thing didn't just win the heavyweights — it humiliated them. On terser, antd, and the monstrous TypeScript package, oxc-minify took gold in *size*, which is the trophy that actually pays your users' phone bills. On TypeScript, it shaved over a megabyte down to 852 KB... in 531 milliseconds. Half a second. For context, uglify-js needed nearly six seconds just to handle victory, a file half that size. And here's the kicker: in the rounds oxc didn't win, it usually lost by a rounding error. On jquery it trailed the leader by 0.07 KB — seven bytes — while running at the same speed as the self-declared sprinters. When your worst case is "within about one percent, but ten times faster," you're not a trade-off. You're a cheat code. Compression champs like uglify-js could still out-squeeze it on the small stuff, but they paid in seconds, and oxc paid in nothing. The crown goes to the tool that made the hardest race look like a warm-up jog.
+The crown goes to **oxc-minify**, and it's the kind of victory that makes statisticians nervous.
+
+Here's the story of the race. On raw compression, @swc/core actually grabbed more "best size" banners—it was often within half a percent of the absolute floor while still clocking absurd times like 46 ms on "jquery." But oxc-minify refused to lose that coin flip. It ran *three to four times faster than swc* nearly every lap, and its compression penalty was typically a rounding error—think 43.25 KB versus 42.71 KB on "vue," a gap your users will never feel over a wire.
+
+Then came the heavyweight rounds, and the race broke open. On "antd" and the towering "typescript" package, oxc-minify posted the smallest result *and* the best meaningful speed—852.78 KB from 1.88 MB in 531 ms. When the source gets big and mean, oxc didn't just keep pace; it led from the front. A tool that sits within a whisper of the compression champions while being dramatically quicker? In a world of CI pipelines and per-deploy budgets, that's your overall winner. It wasn't a landslide—but it was decisive.
 
 ### Honorable mentions
 
-First, a standing ovation for **@swc/core**, the metronome of this event. Four round wins, including jquery, vue, three, and the beastly echarts — and never once off the podium in spirit. If oxc is the flashy sprinter, swc is the tireless distance runner: top-two size in nearly every round at speeds most tools would call ambitious. Choose it and you will never be embarrassed. Next, **uglify-js**, the aging craftsman who still out-squeezes everyone on the little packages — best compression on react, moment, lodash, and a jaw-dropping 157 KB out of victory. But watch the clock, folks: on the big files this artisan works at sculptor's pace, and in 2026, five-plus seconds a build is a luxury. **@cminify** deserves a nod as the pure speed demon — fastest in the heavyweight division every single time — but its compression is often ten-plus percent behind the leaders, which means it's winning the sprint while shipping a fatter payload. A niche tool, and it knows it. Quietly solid showings from **terser**, **esbuild**, and **@tdewolff/minify** — tdewolff in particular kept pace with the big names on echarts and typescript while barely breaking a sweat. Respectable, dependable, just not champion material this year.
+**@swc/core** is the heartbreak story of the season—the perennial silver medalist. It claimed the best-size crown in "jquery," "vue," "three," and "echarts," and never finished far off the pace anywhere. If you want maximum squeeze and can spare the extra milliseconds, this is a magnificent pick.
+
+**uglify-js** is the old master with creaking knees. It authored the most beautiful compressions in the small and medium rounds—8.18 KB on "react," a gorgeous 24.69 KB on "lodash." But 5.7 seconds on "victory" and 3.2 seconds on "d3" in a field where oxc does the same job in 72 ms? Craftsmanship this slow is a luxury, not a strategy.
+
+**@tdewolff/minify** deserves applause as the pocket rocket of the mid-field—7 ms on "moment," 12 ms on "jquery," and respectable sizes to boot. It drifted back on the giants, but for small-to-medium payloads it's a genuinely compelling speed merchant.
+
+**@cminify/cminify-linux-x64** won every sprint it entered but paid dearly at the toll booth—on "typescript" it produced 1.13 MB where oxc managed 852 KB. Fastest lap, worst fuel economy. A niche tool, not a champion.
+
+**esbuild** stayed quietly respectable, and **terser** and **bun** kept the veterans honest without stealing a podium.
 
 ### Eliminated
 
-Two runners were escorted off the track. **babel-minify** never got started — it face-planted on the very first hurdle, react, tripped over its own dependency data and crashed before minification even began. A DNS-worthy performance. And **tedivm/jshrink** made it halfway through the course before a regex pattern it couldn't close brought it down mid-d3, a RuntimeException where a minified file should be. You can't ship output you never produced. Farewell to both.
+- **babel-minify** — never left the garage. Its "react" run died before minification even began, tripping over a stale `baseline-browser-mapping` warning it apparently couldn't look past. DNF.
+- **tedivm/jshrink** — ran bravely until "d3," then collapsed mid-stride with an "Unclosed regex pattern" runtime exception. When your minifier crashes on the sixth-largest file, you're out of the race.
 
 ### Closing remarks
 
-What a race. A new guard has arrived: the Rust-powered sprinters aren't just fast anymore — they're winning on size, the one battlefield the old masters thought was theirs forever. That said, remember this scoreboard only measures gzip bytes and stopwatch ticks. Install weight, API design, community health, and whether the tool actually plays nice with your codebase all live outside these numbers, and they matter plenty when the real decision gets made. So take the results as a starting line, not a finish line — try the contenders, run your own code through them, and crown the champion that fits *your* pipeline. Until next time: keep it small, keep it fast, and may all your semicolons be optional.
+What a day of racing. The Rust generation has officially taken the podium—oxc-minify and @swc/core now trade blows at speeds that make a decade-old toolchain look like dial-up—while uglify-js reminds us that old-fashioned patience still buys the occasional masterpiece. One caution before you sprint to install: these benchmarks measure size and speed, nothing more. Real-world choice also hinges on correctness, API ergonomics, install footprint, and community support—none of which fit on a stopwatch. So take the data, test the finalists against your own code, and pick the one that fits your pipeline. Until next time: keep it small, keep it fast, and may your gzip ratios ever shrink!
 <!-- aiAnalysis:end -->
 
 <details>


### PR DESCRIPTION
## Problem

The Benchmark workflow commits benchmark results and the README report to Renovate's dependency PRs ([#861](https://github.com/privatenumber/minification-benchmarks/pull/861)). When Renovate rebases or updates such a PR, it [recreates the branch from `master`](https://docs.renovatebot.com/updating-rebasing/) and discards those generated commits. The next CI run then re-runs every minification from scratch.

Recent runs on #861 spent 7m35s and 8m41s just in the benchmark step. Every Renovate rebase paid that again, even when only a commit message or README wording had changed.

## Changes

The workflow now saves `packages/data/data/data.json` to the [GitHub Actions cache](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) and restores it before benchmarking. A PR cache survives force-pushes because GitHub scopes it to the PR, not to a commit, so results from the previous run are restored after a rebase. The existing runner logic (`hasResults()`) then skips every minifier whose version and configuration are unchanged, and only new or updated minifiers are measured.

The cache key hashes the dependency lockfiles and the checked-out `data.json`:

- same dependencies and starting results after a rebase → restore the completed measurements,
- dependencies or committed results changed → cache miss, and the runner measures what's missing,
- the starting `data.json` in the key prevents a restored snapshot from overwriting committed corrections,
- if the cache is empty or evicted, the workflow simply benchmarks as before.

Results are saved before the git and report steps, so a report failure no longer discards completed measurements. Workflow actions were also updated to their current major versions (checkout v7, setup-node v7, pnpm/action-setup v6, setup-java v6, cache v6).
