### PR TITLE
perf: reuse AI analysis while generation inputs are unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,28 +424,29 @@ How long minification took (average of 5 runs). Each time is annotated with a mu
 > 🤖 This analysis is AI generated. See below for the system prompt.
 
 <!-- aiAnalysis:start -->
-Three... two... one... compress! Welcome to the Minification Grand Prix, where every byte counts, every millisecond stings, and eleven brave tools lined up to shave a mountain of JavaScript down to a pebble. From dainty little React to the absolute colossus that is TypeScript at nearly two megabytes gzipped, this year's circuit was brutal—and the leaderboard shook more than once.
+<!-- data-hash: 0fcd16c859 -->
+Three... two... one... compress! Welcome back to the Minification Grand Prix, where megabytes go in and dignity comes out — hopefully in fewer kilobytes than it arrived. Twelve rounds, eleven contenders, and a field so deep that some genuinely excellent tools didn't even crack the podium. This year belonged to the new generation of Rust-powered speedsters, but an old warlord had something to say about the small stuff. Buckle up.
 
 ### Best minifier
-The crown goes to **oxc-minify**, and honestly, it didn't just win—it rewrote what "young contender" means. On the small classics it stayed glued to the leaders, but where the race was truly decided—on the big, scary artifacts—it pulled away. On terser itself it took the size win outright. On antd and TypeScript, it delivered the smallest output of anyone, *and* did it in a fraction of the time its rivals needed. Chewing through 1.88 MB of gzipped TypeScript in half a second while producing the tightest result in the field? That's not a trade-off, that's a flex. @swc/core pushed it hard all season and stole several rounds, but when the heaviest weights came out, oxc had both the smallest suitcase and the fastest hands. Verdict: undefeated where it matters most.
+
+The crown goes to **oxc-minify**, and honestly, the judges barely needed to deliberate. Look at the arc of this tournament: it opens with a near-miss on react (8.36 KB versus uglify's 8.18 — a rounding error at 140× the speed), trades blows in the middle rounds, and then goes absolutely supernova when the tracks get long. On terser's own source code it takes the win outright. On antd it wins. On typescript — the marathon of marathons, nearly two megabytes gzipped — it posts 852.78 KB in 531 milliseconds, a time so fast that some competitors hadn't finished reading the file. Its only real blemish is three.js, where it concedes by roughly one percent to @swc/core. One percent. That's not a defeat, that's a rounding hiccup. When compression is this close and the speed gap is this absurd, the trophy has one name on it.
 
 ### Honorable mentions
-**@swc/core** was the metronome of this Grand Prix—rarely the flashiest, almost always on the podium. It took jquery, vue, three, and echarts on raw compression, and stayed within breathing distance of oxc everywhere else. If you want near-best size without babysitting slow builds, this is your workhorse.
 
-**uglify-js** deserves a standing ovation and a nap. It claimed the size crown on react, moment, lodash, and the monstrous victory—proving the old guard can still squeeze with the best of them. The catch? Victory took it nearly six seconds. Beautiful compression, glacial pace. A purist's champion.
+First, the silver medal and a thunderous round of applause for **@swc/core**, which might be the most complete athlete on the grid. It wins jquery, vue, three, and echarts outright — including that monstrous 684 KB echarts track where it shaved 53% while oxc gasped for air half a percent behind. Its consistency is frankly eerie: top-two compression in nearly every round, and never embarrassingly slow. If oxc hadn't shown up with jet fuel in the tank, this would have been swc's year.
 
-**@tdewolff/minify** was the pocket rocket of the early laps—blistering 7-millisecond runs on moment and respectable size throughout, even on echarts. Never quite the smallest, never off the pace.
+Then there's **uglify-js**, the grizzled veteran in a trench coat. It takes best-compression on react, moment, lodash, d3, and victory — but look at the price tag: 5,712 milliseconds on victory, 3,272 on d3. It wins sprint medals by walking, and by the time the courses get truly massive, it's lapped by the newcomers. Glorious, and increasingly a niche specialist.
 
-And a tip of the hat to **@cminify**, the speed specialist: fastest in nearly every heavyweight round, but consistently giving up 10–15% more bytes. That's a lot of extra payload to pay for speed—and when oxc and swc are this fast anyway, it's a hard bill to justify.
-
-**terser** and **esbuild** showed flashes—terser's early-round numbers were solid, esbuild stayed respectable on lodash—but neither could sustain a challenge across the full season.
+**@tdewolff/minify** deserves a raised eyebrow of respect — fastest in the early rounds, and quietly competitive on typescript at 875 KB in 266 ms. It loses a bit of compression as the files grow, but as a raw speed play it's a legitimate pick. And **@cminify/cminify-linux-x64** is the speed demon of the back markers: lightning-quick every single round, but its output is consistently ten to forty percent fatter. Fast food, plenty of calories. Meanwhile **terser**, **esbuild**, **bun**, and **google-closure-compiler** all finished the race without incident — solid machinery, just outpaced by a field operating at another altitude.
 
 ### Eliminated
-- **babel-minify**: Collapsed before the starting gun on react, tripping over its own baseline-browser-mapping dependency warning. A DNS-style failure at the gate—no times recorded.
-- **tedivm/jshrink**: Ran valiantly through the early rounds, then hit an unclosed regex on d3 and bowed out with a PHP RuntimeException. When a minifier breaks the input it's handed, the bench is the only safe place.
+
+- **babel-minify** — Collapsed before the starting gun. An unrelated dependency nagging about stale baseline-browser-mapping data left it unable to even locate its input on the very first round. A DNS at the wrong address; no lap completed.
+- **tedivm/jshrink** — Ran heroically through seven rounds before d3 handed it an unclosed regex pattern deep in minification. When your engine throws a RuntimeException mid-lap, the marshals have no choice but to wave the red flag.
 
 ### Closing remarks
-What a race. The new generation—oxc and swc—has officially closed the gap with the veterans, and then some: today they out-compress *and* out-run them. Meanwhile, uglify-js reminds us that pure size obsession still has a home, if you can stomach the wait. A friendly reminder before you sprint to the terminal: benchmarks measure speed and bytes, not developer joy—install size, API ergonomics, and ecosystem support all live outside this scoreboard. And as always, minifiers can break things, so keep those tests green. Pick the tool that fits your pipeline, your patience, and your users' download budgets—and may your bundles forever shrink. See you at the next Grand Prix!
+
+What a race. The story of 2026 is unmistakably the rise of the Rust brigade — oxc-minify and @swc/core are delivering yesterday's compression at tomorrow's speeds, and the old guard is officially playing a different game. But remember: this benchmark measures only size and speed. Install footprint, API ergonomics, ecosystem support, and correctness in *your* codebase are chapters this scoreboard doesn't tell. Take the winner's circle as a starting point, not a verdict — then go try them on your own bundle. Your users' 4G connections will thank you.
 <!-- aiAnalysis:end -->
 
 <details>

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -9,7 +9,7 @@
 		"@minification-benchmarks/utils": "workspace:*",
 		"ai": "^7.0.34",
 		"chartjs-plugin-datalabels": "^2.2.0",
-		"comment-mark": "^2.0.1",
+		"comment-mark": "^2.1.0",
 		"date-fns": "^4.1.0",
 		"lodash-es": "^4.17.21",
 		"md-pen": "^1.2.0",

--- a/packages/data/update-readme/ai-analysis/index.ts
+++ b/packages/data/update-readme/ai-analysis/index.ts
@@ -19,16 +19,17 @@ export const getDataHash = async () => {
 export const getAiAnalysis = async (
 	minifiers: MinifierLoaded[],
 	data: AnalyzedData,
+	dataHash: string,
 ) => {
-	const todaysDate = `Today's date is ${new Date().toISOString().split('T')[0]}`;
-	const systemPromptPath = new URL('system-prompt.txt', import.meta.url);
-	const systemPrompt = await fs.readFile(systemPromptPath.pathname, 'utf8');
-	const message = await getMessage(minifiers, data);
-
 	if (!apiKey) {
 		console.warn('Skipping AI analysis due to missing VERCEL_AI_GATEWAY_API_KEY');
 		return;
 	}
+
+	const todaysDate = `Today's date is ${new Date().toISOString().split('T')[0]}`;
+	const systemPromptPath = new URL('system-prompt.txt', import.meta.url);
+	const systemPrompt = await fs.readFile(systemPromptPath.pathname, 'utf8');
+	const message = await getMessage(minifiers, data);
 
 	const systemPromptWithDate = `${todaysDate}\n\n${systemPrompt}`;
 
@@ -41,6 +42,6 @@ export const getAiAnalysis = async (
 	return {
 		systemPrompt: `${systemPromptWithDate}\n\n${message}`,
 		analysis: text.replaceAll('\n---\n', ''),
-		dataHash: await getDataHash(),
+		dataHash,
 	};
 };

--- a/packages/data/update-readme/ai-analysis/index.ts
+++ b/packages/data/update-readme/ai-analysis/index.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import crypto from 'node:crypto';
 import { createGateway, generateText } from 'ai';
 import type { MinifierLoaded } from '@minification-benchmarks/minifiers';
 import type { AnalyzedData } from '../analyzed-data.ts';
@@ -6,6 +7,14 @@ import { getMessage } from './get-message.ts';
 
 const apiKey = process.env.VERCEL_AI_GATEWAY_API_KEY;
 const gateway = createGateway({ apiKey });
+
+const dataPath = new URL('../../data/data.json', import.meta.url);
+
+// Identifies the benchmark data an AI analysis was generated from
+export const getDataHash = async () => {
+	const contents = await fs.readFile(dataPath, 'utf8');
+	return crypto.createHash('sha256').update(contents).digest('hex').slice(0, 10);
+};
 
 export const getAiAnalysis = async (
 	minifiers: MinifierLoaded[],
@@ -32,5 +41,6 @@ export const getAiAnalysis = async (
 	return {
 		systemPrompt: `${systemPromptWithDate}\n\n${message}`,
 		analysis: text.replaceAll('\n---\n', ''),
+		dataHash: await getDataHash(),
 	};
 };

--- a/packages/data/update-readme/ai-analysis/index.ts
+++ b/packages/data/update-readme/ai-analysis/index.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import crypto from 'node:crypto';
 import { createGateway, generateText } from 'ai';
 import type { MinifierLoaded } from '@minification-benchmarks/minifiers';
 import type { AnalyzedData } from '../analyzed-data.ts';
@@ -8,18 +7,9 @@ import { getMessage } from './get-message.ts';
 const apiKey = process.env.VERCEL_AI_GATEWAY_API_KEY;
 const gateway = createGateway({ apiKey });
 
-const dataPath = new URL('../../data/data.json', import.meta.url);
-
-// Identifies the benchmark data an AI analysis was generated from
-export const getDataHash = async () => {
-	const contents = await fs.readFile(dataPath, 'utf8');
-	return crypto.createHash('sha256').update(contents).digest('hex').slice(0, 10);
-};
-
 export const getAiAnalysis = async (
 	minifiers: MinifierLoaded[],
 	data: AnalyzedData,
-	dataHash: string,
 ) => {
 	if (!apiKey) {
 		console.warn('Skipping AI analysis due to missing VERCEL_AI_GATEWAY_API_KEY');
@@ -42,6 +32,5 @@ export const getAiAnalysis = async (
 	return {
 		systemPrompt: `${systemPromptWithDate}\n\n${message}`,
 		analysis: text.replaceAll('\n---\n', ''),
-		dataHash,
 	};
 };

--- a/packages/data/update-readme/index.ts
+++ b/packages/data/update-readme/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { outdent } from 'outdent';
-import { commentMark } from 'comment-mark';
+import { commentMark, getCommentMarks } from 'comment-mark';
 import { format } from 'date-fns';
 import { capitalize } from 'lodash-es';
 import type { BenchmarkResultSuccessWithRuns } from '@minification-benchmarks/bench/types.ts';
@@ -10,7 +10,7 @@ import { getMinifiers } from '@minification-benchmarks/minifiers';
 import md from 'md-pen';
 import { byteSize } from '../utils/byte-size.ts';
 import { percent, formatMs } from './formatting.ts';
-import { getAiAnalysis } from './ai-analysis/index.ts';
+import { getAiAnalysis, getDataHash } from './ai-analysis/index.ts';
 import {
 	getAnalyzedData, type AnalyzedData, type AnalyzedArtifact,
 } from './analyzed-data.ts';
@@ -134,13 +134,24 @@ const generateBenchmarks = (
 const minifiers = await getMinifiers();
 
 const analyzedData = getAnalyzedData();
-const ai = await getAiAnalysis(
-	minifiers,
-	analyzedData,
-);
 
 const readmePath = './README.md';
 const readme = await fs.readFile(readmePath, 'utf8');
+
+const dataHash = await getDataHash();
+// The AI analysis section records the data hash it was generated from, so
+// unchanged benchmark data reuses the existing analysis instead of
+// re-requesting it
+const existingAnalysisHash = getCommentMarks(readme).aiAnalysis?.match(
+	/^<!--\s*data-hash:\s*(\S+)\s*-->/,
+)?.[1];
+const isAnalysisCurrent = existingAnalysisHash === dataHash;
+const ai = isAnalysisCurrent
+	? undefined
+	: await getAiAnalysis(
+		minifiers,
+		analyzedData,
+	);
 
 const minifiersList = md.table([
 	['Minifier', 'Version', 'Release date ↓'],
@@ -175,11 +186,13 @@ const escapeHtml = (string_ = '') => string_
 	.replaceAll('\'', '&#39;');
 
 const newReadme = commentMark(readme, {
-	lastUpdated: format(utcToday, 'MMM d, y'),
+	// Leave the date untouched when the benchmark data is unchanged so runs
+	// don't produce a date-only commit
+	lastUpdated: isAnalysisCurrent ? undefined : format(utcToday, 'MMM d, y'),
 	benchmarks: generateBenchmarks(analyzedData),
 	minifiers: minifiersList,
-	aiSystemPrompt: escapeHtml(ai?.systemPrompt),
-	aiAnalysis: ai?.analysis,
+	aiSystemPrompt: ai && escapeHtml(ai.systemPrompt),
+	aiAnalysis: ai && `<!-- data-hash: ${ai.dataHash} -->\n${ai.analysis}`,
 });
 
 await fs.writeFile(readmePath, newReadme);

--- a/packages/data/update-readme/index.ts
+++ b/packages/data/update-readme/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import crypto from 'node:crypto';
 import { outdent } from 'outdent';
 import { commentMark, getCommentMarks } from 'comment-mark';
 import { format } from 'date-fns';
@@ -10,7 +11,7 @@ import { getMinifiers } from '@minification-benchmarks/minifiers';
 import md from 'md-pen';
 import { byteSize } from '../utils/byte-size.ts';
 import { percent, formatMs } from './formatting.ts';
-import { getAiAnalysis, getDataHash } from './ai-analysis/index.ts';
+import { getAiAnalysis } from './ai-analysis/index.ts';
 import {
 	getAnalyzedData, type AnalyzedData, type AnalyzedArtifact,
 } from './analyzed-data.ts';
@@ -136,14 +137,22 @@ const minifiers = await getMinifiers();
 const analyzedData = getAnalyzedData();
 
 const readmePath = './README.md';
-const readme = await fs.readFile(readmePath, 'utf8');
+const [readme, dataContents] = await Promise.all([
+	fs.readFile(readmePath, 'utf8'),
+	fs.readFile(new URL('../data/data.json', import.meta.url), 'utf8'),
+]);
 
-const dataHash = await getDataHash();
-// The AI analysis section records the data hash it was generated from, so
-// unchanged benchmark data reuses the existing analysis instead of
-// re-requesting it
-const existingAnalysisHash = getCommentMarks(readme).aiAnalysis?.match(
-	/^<!--\s*data-hash:\s*(\S+)\s*-->/,
+// Identifies the benchmark data the AI analysis was generated from
+const dataHash = crypto
+	.createHash('sha256')
+	.update(dataContents)
+	.digest('hex')
+	.slice(0, 10);
+
+const existingSections = getCommentMarks(readme);
+const existingAnalysisHash = existingSections.aiAnalysis?.match(
+	// commentMark wraps multiline replacements in newlines, so allow leading whitespace
+	/^\s*<!--\s*data-hash:\s*(\S+)\s*-->/,
 )?.[1];
 const isAnalysisCurrent = existingAnalysisHash === dataHash;
 const ai = isAnalysisCurrent
@@ -151,7 +160,6 @@ const ai = isAnalysisCurrent
 	: await getAiAnalysis(
 		minifiers,
 		analyzedData,
-		dataHash,
 	);
 
 const minifiersList = md.table([
@@ -186,14 +194,20 @@ const escapeHtml = (string_ = '') => string_
 	.replaceAll('"', '&quot;')
 	.replaceAll('\'', '&#39;');
 
+const benchmarks = generateBenchmarks(analyzedData);
+
 const newReadme = commentMark(readme, {
-	// Leave the date untouched when the benchmark data is unchanged so runs
-	// don't produce a date-only commit
-	lastUpdated: isAnalysisCurrent ? undefined : format(utcToday, 'MMM d, y'),
-	benchmarks: generateBenchmarks(analyzedData),
+	// Update the date only when the rendered benchmark section actually changed,
+	// so unchanged data doesn't produce a date-only commit
+	lastUpdated: existingSections.benchmarks?.trim() === benchmarks.trim()
+		? undefined
+		: format(utcToday, 'MMM d, y'),
+	benchmarks,
 	minifiers: minifiersList,
 	aiSystemPrompt: ai && escapeHtml(ai.systemPrompt),
-	aiAnalysis: ai && `<!-- data-hash: ${ai.dataHash} -->\n${ai.analysis}`,
+	// Record the hash only on a successful generation, so a skipped or failed
+	// run never marks the old analysis as current
+	aiAnalysis: ai && `<!-- data-hash: ${dataHash} -->\n${ai.analysis}`,
 });
 
 await fs.writeFile(readmePath, newReadme);

--- a/packages/data/update-readme/index.ts
+++ b/packages/data/update-readme/index.ts
@@ -151,6 +151,7 @@ const ai = isAnalysisCurrent
 	: await getAiAnalysis(
 		minifiers,
 		analyzedData,
+		dataHash,
 	);
 
 const minifiersList = md.table([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(chart.js@4.5.0)
       comment-mark:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.1.0
+        version: 2.1.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -984,48 +984,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.141.0':
     resolution: {integrity: sha512-Xkb5QCOywz/YbL+8LVQSzOxuz2jhRweBjr4BnQO7CQXAtQLLCNoll7v2qLg9OCzdqdhFw9uNgZ6aTBVADBhiPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.141.0':
     resolution: {integrity: sha512-IbVb+m0iL053WitFNnQbtmd8OjYGr4Xn5NTuAiYz8tJBtn82okEZFi0OgaeaHQE4aPZGOKPcSVlt1OMPtMoPCw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.141.0':
     resolution: {integrity: sha512-Sc/GAiyelxg8oXlBgmJI6OuKKHmg4rF0RvTLC8eL5V3qKDXrMdVWiJziwVBqN5oiFEog35ZM1/YNF63IZOdZjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.141.0':
     resolution: {integrity: sha512-KHYS3oQJ5r1QBVAVubUy6UPRWYghqkjCOfNlGeH/sWlmfeM2OD74+Stc8eHmVm7QI2wDooOIlZfUso0Yz0jyRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.141.0':
     resolution: {integrity: sha512-WyacIrs13ewOnGngxNmPF00xn0+aOYHTMSSMljNN3VShSbqB0A7ZEikR7q9fmmnBTf/jloQUO6bjzK85BFfl0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.141.0':
     resolution: {integrity: sha512-mP69bh2L/VVq10UEQ3wb0EsO0472TzOIZUfS/ADmxnr4gSxAzhRbO8w5QryL3BNyyyjSaXIlrAnAKO6G3srGwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.141.0':
     resolution: {integrity: sha512-B4w1uz+GPVD5iRNn9StLSG0ug5DNAy5YQVswjPy5fXNNO6JyADvmu4KZyE6tWCA6Kbz/84icD6RJ1TKVis2HSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.141.0':
     resolution: {integrity: sha512-p3nU1bo2t+QRvvqOPUqI8aEk8puhYdMq5cnjulovfKykWRi8cMcJJvuLp+RPkf45lUcTQdNG/YMFqR5eYGZfwA==}
@@ -1098,36 +1106,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.46':
     resolution: {integrity: sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.46':
     resolution: {integrity: sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.46':
     resolution: {integrity: sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.46':
     resolution: {integrity: sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.46':
     resolution: {integrity: sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.46':
     resolution: {integrity: sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==}
@@ -1463,41 +1477,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1868,8 +1890,8 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  comment-mark@2.0.1:
-    resolution: {integrity: sha512-WObl+IX0fmiQYgt/pMTquyAYBdcKf8GQGPVPDNtL7XvDQDUdfHaOJYayzsLGS24GHLuHhFXgVXmwwq6CM1lHcQ==}
+  comment-mark@2.1.0:
+    resolution: {integrity: sha512-zD6uWUWisl14bwAL418enjYtmL26u/a8wsFO+XviFFn16bbWFDXylfYfT2irQ4o0ySk8z0k7QfAzaO8Qq1b/CA==}
     engines: {node: '>=20'}
 
   comment-parser@1.4.1:
@@ -2389,6 +2411,7 @@ packages:
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5944,7 +5967,7 @@ snapshots:
 
   commander@2.20.3: {}
 
-  comment-mark@2.0.1: {}
+  comment-mark@2.1.0: {}
 
   comment-parser@1.4.1: {}
 


### PR DESCRIPTION
## Problem

`pnpm update-readme` asks the model to regenerate the README's benchmark analysis on every run, even when nothing that shapes the analysis has changed. Re-running the workflow, and running it locally, both pay for identical prose.

Each generation is now a full [GLM-5.3](https://opencode.ai/docs/go/) request at max reasoning from #868: roughly two and a half minutes in CI, drawn from the model's smaller monthly allowance.

## Changes

The analysis is reused while its generation inputs are unchanged. The analysis section records a SHA-256 fingerprint of the provider, model, system prompt, and generated benchmark message in a hidden `<!-- analysis-hash: ... -->` comment. Before generating, the command compares that fingerprint against the current inputs; on a match it makes no request and preserves the existing analysis and prompt exactly.

- The fingerprint excludes the current date, which the prompt embeds, so an unchanged analysis stays valid across days.
- The "last updated" date moves only when the rendered benchmark section changes, so unchanged data no longer creates a date-only commit.
- A skipped or failed generation never records a fingerprint, so an older analysis is never mistaken for current.

Uses `getCommentMarks()` from [comment-mark v2.1.0](https://github.com/privatenumber/comment-mark/releases/tag/v2.1.0). In CI an unchanged run drops from about two and a half minutes to about three seconds.

## Scope

The fingerprint lives in the README, so the analysis is reused only while the surrounding report survives. A Renovate branch recreated from the base branch loses the generated report commit and regenerates the analysis. #866 keeps `data.json` across that recreation; caching the report itself would be a separate change.
